### PR TITLE
Add LayerType and LastTradeType flags to each layer to determine which PQQuoteLevel a PQServer should publish as by default.

### DIFF
--- a/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfo.cs
+++ b/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfo.cs
@@ -5,6 +5,7 @@ using FortitudeCommon.DataStructures.Memory;
 using FortitudeCommon.Types;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 
 #endregion
 
@@ -17,6 +18,7 @@ public interface ISourceTickerQuoteInfo : IInterfacesComparable<ISourceTickerQuo
     ushort TickerId { get; set; }
     string Source { get; set; }
     string Ticker { get; set; }
+    QuoteLevel PublishedQuoteLevel { get; set; }
     decimal RoundingPrecision { get; set; }
     decimal MinSubmitSize { get; set; }
     decimal MaxSubmitSize { get; set; }
@@ -38,8 +40,8 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         Ticker = null!;
     }
 
-    public SourceTickerQuoteInfo(ushort sourceId, string source, ushort tickerId, string ticker, byte maximumPublishedLayers = 20,
-        decimal roundingPrecision = 0.0001m, decimal minSubmitSize = 0.01m, decimal maxSubmitSize = 1_000_000m,
+    public SourceTickerQuoteInfo(ushort sourceId, string source, ushort tickerId, string ticker, QuoteLevel publishedQuoteLevel,
+        byte maximumPublishedLayers = 20, decimal roundingPrecision = 0.0001m, decimal minSubmitSize = 0.01m, decimal maxSubmitSize = 1_000_000m,
         decimal incrementSize = 0.01m, ushort minimumQuoteLife = 100,
         LayerFlags layerFlags = LayerFlags.Price | LayerFlags.Volume,
         LastTradedFlags lastTradedFlags = LastTradedFlags.None)
@@ -48,6 +50,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         TickerId = tickerId;
         Source = source;
         Ticker = ticker;
+        PublishedQuoteLevel = publishedQuoteLevel;
         MaximumPublishedLayers = maximumPublishedLayers;
         RoundingPrecision = roundingPrecision;
         MinSubmitSize = minSubmitSize;
@@ -64,6 +67,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         TickerId = toClone.TickerId;
         Source = toClone.Source;
         Ticker = toClone.Ticker;
+        PublishedQuoteLevel = toClone.PublishedQuoteLevel;
         MaximumPublishedLayers = toClone.MaximumPublishedLayers;
         RoundingPrecision = toClone.RoundingPrecision;
         MinSubmitSize = toClone.MinSubmitSize;
@@ -83,6 +87,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
     public ushort TickerId { get; set; }
     public string Source { get; set; }
     public string Ticker { get; set; }
+    public QuoteLevel PublishedQuoteLevel { get; set; }
     public byte MaximumPublishedLayers { get; set; }
     public decimal RoundingPrecision { get; set; }
     public decimal MinSubmitSize { get; set; }
@@ -111,6 +116,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         var tickerIdSame = TickerId == other?.TickerId;
         var sourceSame = Source == other?.Source;
         var tickerSame = Ticker == other?.Ticker;
+        var quoteLevelSame = PublishedQuoteLevel == other?.PublishedQuoteLevel;
         var maxPublishedLayersSame = MaximumPublishedLayers == other?.MaximumPublishedLayers;
         var roundingPrecisionSame = RoundingPrecision == other?.RoundingPrecision;
         var minSubmitSizeSame = MinSubmitSize == other?.MinSubmitSize;
@@ -120,7 +126,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         var layerFlagsSame = LayerFlags == other?.LayerFlags;
         var lastTradedFlagsSame = LastTradedFlags == other?.LastTradedFlags;
 
-        return sourceIdSame && tickerIdSame && sourceSame && tickerSame && maxPublishedLayersSame && roundingPrecisionSame
+        return sourceIdSame && tickerIdSame && sourceSame && tickerSame && quoteLevelSame && maxPublishedLayersSame && roundingPrecisionSame
                && minSubmitSizeSame && maxSubmitSizeSame && incrmntSizeSame && minQuoteLifeSame && layerFlagsSame && lastTradedFlagsSame;
     }
 
@@ -130,6 +136,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         TickerId = source.TickerId;
         Source = source.Source;
         Ticker = source.Ticker;
+        PublishedQuoteLevel = source.PublishedQuoteLevel;
         RoundingPrecision = source.RoundingPrecision;
         MinSubmitSize = source.MinSubmitSize;
         MaxSubmitSize = source.MaxSubmitSize;
@@ -151,6 +158,7 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
             hashCode = (hashCode * 397) ^ TickerId;
             hashCode = (hashCode * 397) ^ Source.GetHashCode();
             hashCode = (hashCode * 397) ^ Ticker.GetHashCode();
+            hashCode = (hashCode * 397) ^ PublishedQuoteLevel.GetHashCode();
             hashCode = (hashCode * 397) ^ MaximumPublishedLayers.GetHashCode();
             hashCode = (hashCode * 397) ^ (formatPrice != null ? formatPrice.GetHashCode() : 0);
             hashCode = (hashCode * 397) ^ RoundingPrecision.GetHashCode();
@@ -166,9 +174,9 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
 
     public override string ToString() =>
         $"SourceTickerQuoteInfo {{{nameof(Id)}: {Id}, {nameof(SourceId)}: {SourceId}, {nameof(Source)}: {Source}, " +
-        $"{nameof(TickerId)}: {TickerId}, {nameof(Ticker)}: {Ticker},  {nameof(RoundingPrecision)}: {RoundingPrecision}, " +
-        $"{nameof(MinSubmitSize)}: {MinSubmitSize}, {nameof(MaxSubmitSize)}: {MaxSubmitSize}, " +
-        $"{nameof(IncrementSize)}: {IncrementSize}, {nameof(MinimumQuoteLife)}: {MinimumQuoteLife}, " +
-        $"{nameof(LayerFlags)}: {LayerFlags:F}, {nameof(MaximumPublishedLayers)}: {MaximumPublishedLayers}, " +
-        $"{nameof(LastTradedFlags)}: {LastTradedFlags} }}";
+        $"{nameof(TickerId)}: {TickerId}, {nameof(Ticker)}: {Ticker},  {nameof(PublishedQuoteLevel)}: {PublishedQuoteLevel},  " +
+        $"{nameof(RoundingPrecision)}: {RoundingPrecision}, {nameof(MinSubmitSize)}: {MinSubmitSize}, " +
+        $"{nameof(MaxSubmitSize)}: {MaxSubmitSize}, {nameof(IncrementSize)}: {IncrementSize}, " +
+        $"{nameof(MinimumQuoteLife)}: {MinimumQuoteLife}, {nameof(LayerFlags)}: {LayerFlags:F}, " +
+        $"{nameof(MaximumPublishedLayers)}: {MaximumPublishedLayers}, {nameof(LastTradedFlags)}: {LastTradedFlags} }}";
 }

--- a/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickersConfig.cs
+++ b/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickersConfig.cs
@@ -5,6 +5,7 @@ using FortitudeCommon.DataStructures.Lists;
 using FortitudeCommon.Types;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using Microsoft.Extensions.Configuration;
 
 #endregion
@@ -181,7 +182,7 @@ public class SourceTickersConfig : ConfigSection, ISourceTickersConfig
     {
         var tickerConfig = Tickers.FirstOrDefault(tc => tc.Ticker == ticker);
         if (tickerConfig == null) return null;
-        var sourceTickerINfo = new SourceTickerQuoteInfo(sourceId, sourceName, tickerConfig.TickerId, tickerConfig.Ticker
+        var sourceTickerINfo = new SourceTickerQuoteInfo(sourceId, sourceName, tickerConfig.TickerId, tickerConfig.Ticker, QuoteLevel.Level2
             , tickerConfig.MaximumPublishedLayers ?? DefaultMaximumPublishedLayers,
             tickerConfig.RoundingPrecision ?? DefaultRoundingPrecision,
             tickerConfig.MinSubmitSize ?? DefaultMinSubmitSize, tickerConfig.MaxSubmitSize ?? DefaultMaxSubmitSize
@@ -195,7 +196,7 @@ public class SourceTickersConfig : ConfigSection, ISourceTickersConfig
     {
         foreach (var tickerConfig in Tickers)
         {
-            var sourceTickerINfo = new SourceTickerQuoteInfo(sourceId, sourceName, tickerConfig.TickerId, tickerConfig.Ticker
+            var sourceTickerINfo = new SourceTickerQuoteInfo(sourceId, sourceName, tickerConfig.TickerId, tickerConfig.Ticker, QuoteLevel.Level2
                 , tickerConfig.MaximumPublishedLayers ?? DefaultMaximumPublishedLayers,
                 tickerConfig.RoundingPrecision ?? DefaultRoundingPrecision,
                 tickerConfig.MinSubmitSize ?? DefaultMinSubmitSize, tickerConfig.MaxSubmitSize ?? DefaultMaxSubmitSize

--- a/src/FortitudeMarketsApi/Pricing/LastTraded/ILastTrade.cs
+++ b/src/FortitudeMarketsApi/Pricing/LastTraded/ILastTrade.cs
@@ -9,6 +9,8 @@ namespace FortitudeMarketsApi.Pricing.LastTraded;
 
 public interface ILastTrade : IReusableObject<ILastTrade>, IInterfacesComparable<ILastTrade>
 {
+    LastTradeType LastTradeType { get; }
+    LastTradedFlags SupportsLastTradedFlags { get; }
     DateTime TradeTime { get; }
     decimal TradePrice { get; }
     bool IsEmpty { get; }

--- a/src/FortitudeMarketsApi/Pricing/LastTraded/IRecentlyTraded.cs
+++ b/src/FortitudeMarketsApi/Pricing/LastTraded/IRecentlyTraded.cs
@@ -10,6 +10,8 @@ namespace FortitudeMarketsApi.Pricing.LastTraded;
 public interface IRecentlyTraded : IReusableObject<IRecentlyTraded>, IEnumerable<ILastTrade>,
     IInterfacesComparable<IRecentlyTraded>
 {
+    LastTradeType LastTradesOfType { get; }
+    LastTradedFlags LastTradesSupportFlags { get; }
     bool HasLastTrades { get; }
     int Count { get; }
     int Capacity { get; }

--- a/src/FortitudeMarketsApi/Pricing/LastTraded/LastTradeType.cs
+++ b/src/FortitudeMarketsApi/Pricing/LastTraded/LastTradeType.cs
@@ -1,0 +1,34 @@
+﻿#region
+
+using static FortitudeMarketsApi.Pricing.LastTraded.LastTradedFlags;
+
+#endregion
+
+namespace FortitudeMarketsApi.Pricing.LastTraded;
+
+public enum LastTradeType
+{
+    None
+    , Price
+    , PricePaidOrGivenVolume
+    , PriceLastTraderName
+    , PriceLastTraderPaidOrGivenVolume
+}
+
+public static class LastTradeTypeExtensions
+{
+    public static LastTradeType MostCompactLayerType(this LastTradedFlags lastTradedFlags)
+    {
+        return lastTradedFlags switch
+        {
+            None => LastTradeType.None
+            , _ when (lastTradedFlags & (LastTradedPrice | LastTradedTime)) > 0 &&
+                     (lastTradedFlags & (LastTradedVolume | PaidOrGiven | TraderName)) == 0 => LastTradeType.Price
+            , _ when ((lastTradedFlags & LastTradedVolume) | PaidOrGiven) > 0 && (lastTradedFlags & TraderName) == 0 => LastTradeType
+                .PricePaidOrGivenVolume
+            , _ when (lastTradedFlags & TraderName) > 0 && (lastTradedFlags & (PaidOrGiven | LastTradedVolume)) == 0 => LastTradeType
+                .PriceLastTraderName
+            , _ => LastTradeType.PriceLastTraderPaidOrGivenVolume
+        };
+    }
+}

--- a/src/FortitudeMarketsApi/Pricing/LayeredBook/IOrderBook.cs
+++ b/src/FortitudeMarketsApi/Pricing/LayeredBook/IOrderBook.cs
@@ -17,6 +17,8 @@ public enum BookSide
 public interface IOrderBook : IEnumerable<IPriceVolumeLayer>, IReusableObject<IOrderBook>,
     IInterfacesComparable<IOrderBook>
 {
+    LayerType LayersOfType { get; }
+    LayerFlags LayersSupportsLayerFlags { get; }
     int Capacity { get; }
     int Count { get; }
     BookSide BookSide { get; }

--- a/src/FortitudeMarketsApi/Pricing/LayeredBook/IPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsApi/Pricing/LayeredBook/IPriceVolumeLayer.cs
@@ -11,6 +11,8 @@ namespace FortitudeMarketsApi.Pricing.LayeredBook;
 // duplicated 1000s of times in a ring.
 public interface IPriceVolumeLayer : IReusableObject<IPriceVolumeLayer>, IInterfacesComparable<IPriceVolumeLayer>
 {
+    LayerType LayerType { get; }
+    LayerFlags SupportsLayerFlags { get; }
     decimal Price { get; }
     decimal Volume { get; }
     bool IsEmpty { get; }

--- a/src/FortitudeMarketsApi/Pricing/LayeredBook/LayerFlags.cs
+++ b/src/FortitudeMarketsApi/Pricing/LayeredBook/LayerFlags.cs
@@ -16,3 +16,38 @@ public enum LayerFlags : uint
     , Reserved = 0x0E_00
     , UserExtensibile = 0xF0_00
 }
+
+public static class LayerFlagsExtensions
+{
+    public static LayerFlags SupportedLayerFlags(this LayerType layerType)
+    {
+        switch (layerType)
+        {
+            case LayerType.PriceVolume: return LayerFlags.Price | LayerFlags.Volume;
+            case LayerType.ValueDatePriceVolume: return LayerFlags.ValueDate | LayerFlags.Price | LayerFlags.Volume;
+            case LayerType.SourcePriceVolume: return LayerFlags.SourceName | LayerFlags.Price | LayerFlags.Volume;
+            case LayerType.SourceQuoteRefPriceVolume:
+                return LayerFlags.SourceQuoteReference | LayerFlags.SourceName | LayerFlags.Price | LayerFlags.Volume;
+            case LayerType.TraderPriceVolume:
+                return LayerFlags.TraderCount | LayerFlags.TraderName | LayerFlags.TraderSize | LayerFlags.Price | LayerFlags.Volume;
+            case LayerType.SourceQuoteRefTraderValueDatePriceVolume:
+                return LayerFlags.ValueDate | LayerFlags.SourceQuoteReference | LayerFlags.SourceName | LayerFlags.TraderCount
+                       | LayerFlags.TraderName | LayerFlags.TraderSize | LayerFlags.Price | LayerFlags.Volume;
+            default: return LayerFlags.None;
+        }
+    }
+
+    public static bool HasPrice(this LayerFlags flags) => (flags & LayerFlags.Price) > 0;
+    public static bool HasVolume(this LayerFlags flags) => (flags & LayerFlags.Volume) > 0;
+    public static bool HasSourceName(this LayerFlags flags) => (flags & LayerFlags.SourceName) > 0;
+    public static bool HasExecutable(this LayerFlags flags) => (flags & LayerFlags.Executable) > 0;
+    public static bool HasSourceQuoteReference(this LayerFlags flags) => (flags & LayerFlags.SourceQuoteReference) > 0;
+    public static bool HasTraderCount(this LayerFlags flags) => (flags & LayerFlags.TraderCount) > 0;
+    public static bool HasTraderName(this LayerFlags flags) => (flags & LayerFlags.TraderName) > 0;
+    public static bool HasTraderSize(this LayerFlags flags) => (flags & LayerFlags.TraderSize) > 0;
+    public static bool HasValueDate(this LayerFlags flags) => (flags & LayerFlags.ValueDate) > 0;
+    public static bool HasAllOf(this LayerFlags flags, LayerFlags checkAllFound) => (flags & checkAllFound) == checkAllFound;
+    public static bool HasNoneOf(this LayerFlags flags, LayerFlags checkNonAreSet) => (flags & checkNonAreSet) == 0;
+    public static bool HasAnyOf(this LayerFlags flags, LayerFlags checkAnyAreFound) => (flags & checkAnyAreFound) > 0;
+    public static bool IsExactly(this LayerFlags flags, LayerFlags checkAllFound) => flags == checkAllFound;
+}

--- a/src/FortitudeMarketsApi/Pricing/LayeredBook/LayerType.cs
+++ b/src/FortitudeMarketsApi/Pricing/LayeredBook/LayerType.cs
@@ -1,0 +1,39 @@
+﻿#region
+
+using static FortitudeMarketsApi.Pricing.LayeredBook.LayerFlags;
+
+#endregion
+
+namespace FortitudeMarketsApi.Pricing.LayeredBook;
+
+public enum LayerType
+{
+    None
+    , PriceVolume
+    , SourcePriceVolume
+    , SourceQuoteRefPriceVolume
+    , TraderPriceVolume
+    , SourceQuoteRefTraderValueDatePriceVolume
+    , ValueDatePriceVolume
+}
+
+public static class LayerTypeExtensions
+{
+    public static LayerType MostCompactLayerType(this LayerFlags layerFlags)
+    {
+        return layerFlags switch
+        {
+            None => LayerType.None, Price | Volume => LayerType.PriceVolume
+            , _ when layerFlags.HasValueDate() &&
+                     layerFlags.HasNoneOf(SourceQuoteReference | TraderCount | TraderName | TraderSize | SourceName | Executable) =>
+                LayerType.ValueDatePriceVolume
+            , _ when layerFlags.HasAnyOf(SourceName | Executable) &&
+                     layerFlags.HasNoneOf(SourceQuoteReference | TraderCount | TraderName | TraderSize | ValueDate) => LayerType.SourcePriceVolume
+            , _ when layerFlags.HasSourceQuoteReference() && layerFlags.HasNoneOf(TraderCount | TraderName | TraderSize | ValueDate) =>
+                LayerType.SourceQuoteRefPriceVolume
+            , _ when layerFlags.HasAnyOf(TraderCount | TraderName | TraderSize) &&
+                     layerFlags.HasNoneOf(SourceName | Executable | SourceQuoteReference | ValueDate) => LayerType.TraderPriceVolume
+            , _ => LayerType.SourceQuoteRefTraderValueDatePriceVolume
+        };
+    }
+}

--- a/src/FortitudeMarketsApi/Pricing/Quotes/ILevel0Quote.cs
+++ b/src/FortitudeMarketsApi/Pricing/Quotes/ILevel0Quote.cs
@@ -10,6 +10,7 @@ namespace FortitudeMarketsApi.Pricing.Quotes;
 
 public interface ILevel0Quote : IReusableObject<ILevel0Quote>, IInterfacesComparable<ILevel0Quote>
 {
+    QuoteLevel QuoteLevel { get; }
     bool IsReplay { get; }
     DateTime SourceTime { get; }
     DateTime ClientReceivedTime { get; }

--- a/src/FortitudeMarketsApi/Pricing/Quotes/QuoteLevel.cs
+++ b/src/FortitudeMarketsApi/Pricing/Quotes/QuoteLevel.cs
@@ -1,0 +1,31 @@
+﻿#region
+
+using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
+using FortitudeMarketsApi.Pricing.LastTraded;
+using FortitudeMarketsApi.Pricing.LayeredBook;
+
+#endregion
+
+namespace FortitudeMarketsApi.Pricing.Quotes;
+
+public enum QuoteLevel
+{
+    Level0 // used for publishing metrics, indicators or single values not exchange quotes
+    , Level1
+    , Level2
+    , Level3
+}
+
+public static class QuoteLevelExtensions
+{
+    public static QuoteLevel MostCompactQuoteLevel(this ISourceTickerQuoteInfo sourceTickerQuoteInfo)
+    {
+        return sourceTickerQuoteInfo switch
+        {
+            _ when sourceTickerQuoteInfo.LayerFlags.MostCompactLayerType() == LayerType.PriceVolume &&
+                   sourceTickerQuoteInfo is { MaximumPublishedLayers: <= 1, LastTradedFlags: LastTradedFlags.None } => QuoteLevel.Level1
+            , _ when sourceTickerQuoteInfo is { LastTradedFlags: LastTradedFlags.None, MaximumPublishedLayers: > 1 } => QuoteLevel.Level2
+            , _ => QuoteLevel.Level3
+        };
+    }
+}

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/DeltaUpdates/PQFieldKeys.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/DeltaUpdates/PQFieldKeys.cs
@@ -12,35 +12,35 @@ public static class PQFieldKeys
     public const byte SingleByteFieldIdMaxBookDepth = 20;
     public const byte SingleByteFieldIdMaxPossibleLastTrades = 10;
 
-    // Level 0 Fields
     public const byte PQSequenceId = 1;
-    public const byte SinglePrice = 2;
-    public const byte SourceSentDateTime = 3;
-    public const byte SourceSentSubHourTime = 4;
-    public const byte QuoteBooleanFlags = 5;
-    public const byte PQSyncStatus = 6;
-    public const byte SocketReceivingDateTime = 7;
-    public const byte SocketReceivingSubHourTime = 8;
-    public const byte ProcessedDateTime = 9;
-    public const byte ProcessedSubHourTime = 10;
-    public const byte DispatchedDateTime = 11;
-    public const byte DispatchedSubHourTime = 12;
-    public const byte ClientReceivedDateTime = 13;
-
-    public const byte ClientReceivedSubHourTime = 14;
 
     // Source Ticker Info
-    public const byte SourceTickerId = 15;
-    public const byte SourceTickerNames = 16; //StringFieldUpdate
-    public const byte RoundingPrecision = 17;
-    public const byte MinSubmitSize = 18;
-    public const byte MaxSubmitSize = 19;
-    public const byte IncrementSize = 20;
-    public const byte MinimumQuoteLife = 21;
-    public const byte LayerFlags = 22;
-    public const byte MaximumPublishedLayers = 23;
-    public const byte LastTradedFlags = 24;
-    public const byte SourceTickerBooleanFields = 25;
+    public const byte PublishQuoteLevelType = 2;
+    public const byte SourceTickerId = 3;
+    public const byte SourceTickerNames = 4; //StringFieldUpdate
+    public const byte RoundingPrecision = 5;
+    public const byte MinSubmitSize = 6;
+    public const byte MaxSubmitSize = 7;
+    public const byte IncrementSize = 8;
+    public const byte MinimumQuoteLife = 9;
+    public const byte LayerFlags = 10;
+    public const byte MaximumPublishedLayers = 11;
+    public const byte LastTradedFlags = 12;
+
+    // Level 0 Fields
+    public const byte SinglePrice = 13;
+    public const byte SourceSentDateTime = 14;
+    public const byte SourceSentSubHourTime = 15;
+    public const byte QuoteBooleanFlags = 16;
+    public const byte PQSyncStatus = 17;
+    public const byte SocketReceivingDateTime = 18;
+    public const byte SocketReceivingSubHourTime = 19;
+    public const byte ProcessedDateTime = 20;
+    public const byte ProcessedSubHourTime = 21;
+    public const byte DispatchedDateTime = 22;
+    public const byte DispatchedSubHourTime = 23;
+    public const byte ClientReceivedDateTime = 24;
+    public const byte ClientReceivedSubHourTime = 25;
 
     // Level 1 Fields
     public const byte AdapterSentDateTime = 26;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastPaidGivenTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastPaidGivenTrade.cs
@@ -61,6 +61,11 @@ public class PQLastPaidGivenTrade : PQLastTrade, IPQLastPaidGivenTrade
         $"{PQLastTradeToStringMembers}, {nameof(WasPaid)}: {WasPaid}, " +
         $"{nameof(WasGiven)}: {WasGiven}, {nameof(TradeVolume)}: {TradeVolume:N2}";
 
+    public override LastTradeType LastTradeType => LastTradeType.PricePaidOrGivenVolume;
+
+    public override LastTradedFlags SupportsLastTradedFlags =>
+        LastTradedFlags.PaidOrGiven | LastTradedFlags.LastTradedVolume | base.SupportsLastTradedFlags;
+
     public bool WasPaid
     {
         get => (LastTradeBooleanFlags & LastTradeBooleanFlags.WasPaid) > 0;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastTrade.cs
@@ -45,6 +45,8 @@ public class PQLastTrade : ReusableObject<ILastTrade>, IPQLastTrade
     }
 
     protected string PQLastTradeToStringMembers => $"{nameof(TradePrice)}: {TradePrice:N5}, {nameof(TradeTime)}: {TradeTime:O}";
+    public virtual LastTradeType LastTradeType => LastTradeType.Price;
+    public virtual LastTradedFlags SupportsLastTradedFlags => LastTradedFlags.LastTradedPrice | LastTradedFlags.LastTradedTime;
 
     public DateTime TradeTime
     {

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastTraderPaidGivenTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQLastTraderPaidGivenTrade.cs
@@ -46,9 +46,10 @@ public class PQLastTraderPaidGivenTrade : PQLastPaidGivenTrade, IPQLastTraderPai
         if (toClone is ILastTraderPaidGivenTrade lastTraderPaidGivenTrade) TraderName = lastTraderPaidGivenTrade.TraderName;
     }
 
-
     protected string PQLastTraderPaidGivenTradeToStringMembers => $"{PQLastPaidGivenTradeToStringMembers}, {nameof(TraderName)}: {TraderName}";
 
+    public override LastTradeType LastTradeType => LastTradeType.PriceLastTraderPaidOrGivenVolume;
+    public override LastTradedFlags SupportsLastTradedFlags => LastTradedFlags.TraderName | base.SupportsLastTradedFlags;
 
     public int TraderId
     {

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQRecentlyTraded.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/PQRecentlyTraded.cs
@@ -38,6 +38,8 @@ public class PQRecentlyTraded : ReusableObject<IRecentlyTraded>, IPQRecentlyTrad
 
     public PQRecentlyTraded(IPQSourceTickerQuoteInfo sourceTickerQuoteInfo)
     {
+        LastTradesSupportFlags = sourceTickerQuoteInfo.LastTradedFlags;
+        LastTradesOfType = LastTradesSupportFlags.MostCompactLayerType();
         lastTrades = new List<IPQLastTrade?>();
         NameIdLookup = new PQNameIdLookupGenerator(PQFieldKeys.LastTraderDictionaryUpsertCommand);
         EnsureRelatedItemsAreConfigured(sourceTickerQuoteInfo);
@@ -61,6 +63,9 @@ public class PQRecentlyTraded : ReusableObject<IRecentlyTraded>, IPQRecentlyTrad
     }
 
     public IPQLastTradeTypeSelector LastTradeEntrySelector { get; set; } = null!;
+    public LastTradeType LastTradesOfType { get; } = LastTradeType.Price;
+
+    public LastTradedFlags LastTradesSupportFlags { get; } = LastTradedFlags.LastTradedPrice | LastTradedFlags.LastTradedTime;
 
     public IPQNameIdLookupGenerator NameIdLookup
     {

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBook.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBook.cs
@@ -87,6 +87,10 @@ public class PQOrderBook : ReusableObject<IOrderBook>, IPQOrderBook
         $"{nameof(Capacity)}: {Capacity}, {nameof(Count)}: {Count}, " +
         $"{nameof(AllLayers)}:[{string.Join(", ", AllLayers.Take(Count))}]";
 
+    public LayerType LayersOfType { get; } = LayerType.PriceVolume;
+
+    public LayerFlags LayersSupportsLayerFlags { get; } = LayerFlags.Price | LayerFlags.Volume;
+
     public BookSide BookSide { get; }
 
     public IPQPriceVolumeLayer? this[int level]

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQPriceVolumeLayer.cs
@@ -38,6 +38,8 @@ public class PQPriceVolumeLayer : ReusableObject<IPriceVolumeLayer>, IPQPriceVol
     }
 
     protected string PQPriceVolumeLayerToStringMembers => $"{nameof(Price)}: {Price:N5}, {nameof(Volume)}: {Volume:N2}";
+    public virtual LayerType LayerType => LayerType.PriceVolume;
+    public virtual LayerFlags SupportsLayerFlags => LayerFlags.Price | LayerFlags.Volume;
 
     public decimal Price
     {

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourcePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourcePriceVolumeLayer.cs
@@ -61,6 +61,9 @@ public class PQSourcePriceVolumeLayer : PQPriceVolumeLayer, IPQSourcePriceVolume
         $"{PQPriceVolumeLayerToStringMembers}, {nameof(SourceName)}: {SourceName}, " +
         $"{nameof(Executable)}: {Executable}";
 
+    public override LayerType LayerType => LayerType.SourcePriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.SourceName | LayerFlags.Executable | base.SupportsLayerFlags;
+
     public ushort SourceId
     {
         get => sourceId;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourceQuoteRefPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourceQuoteRefPriceVolumeLayer.cs
@@ -38,6 +38,9 @@ public class PQSourceQuoteRefPriceVolumeLayer : PQSourcePriceVolumeLayer, IPQSou
     protected string PQSourceQuoteRefPriceVolumeLayerToStringMembers =>
         $"{PQSourcePriceVolumeLayerToStringMembers}, {nameof(SourceQuoteReference)}: {SourceQuoteReference:N0}";
 
+    public override LayerType LayerType => LayerType.SourceQuoteRefPriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.SourceQuoteReference | base.SupportsLayerFlags;
+
     public uint SourceQuoteReference
     {
         get => sourceQuoteReference;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourceQuoteRefTraderValueDatePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQSourceQuoteRefTraderValueDatePriceVolumeLayer.cs
@@ -64,6 +64,12 @@ public class PQSourceQuoteRefTraderValueDatePriceVolumeLayer : PQTraderPriceVolu
         $"{nameof(SourceQuoteReference)}: {SourceQuoteReference:N0}, {nameof(ValueDate)}: {ValueDate}, " +
         $"{nameof(Count)}: {Count} {PQTraderPriceVolumeLayerToStringMembers}";
 
+    public override LayerType LayerType => LayerType.SourceQuoteRefTraderValueDatePriceVolume;
+
+    public override LayerFlags SupportsLayerFlags =>
+        LayerFlags.SourceQuoteReference | LayerFlags.SourceName
+                                        | LayerFlags.Executable | LayerFlags.ValueDate | base.SupportsLayerFlags;
+
     public DateTime ValueDate
     {
         get => valueDate;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQTraderPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQTraderPriceVolumeLayer.cs
@@ -49,6 +49,9 @@ public class PQTraderPriceVolumeLayer : PQPriceVolumeLayer, IPQTraderPriceVolume
     protected string PQTraderPriceVolumeLayerToStringMembers =>
         $"{PQPriceVolumeLayerToStringMembers}, {nameof(TraderDetails)}: [{string.Join(", ", TraderDetails)}]";
 
+    public override LayerType LayerType => LayerType.TraderPriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.TraderName | LayerFlags.TraderCount | LayerFlags.TraderSize | base.SupportsLayerFlags;
+
     IMutableTraderLayerInfo? IMutableTraderPriceVolumeLayer.this[int i]
     {
         get => this[i];

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQValueDatePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQValueDatePriceVolumeLayer.cs
@@ -32,6 +32,9 @@ public class PQValueDatePriceVolumeLayer : PQPriceVolumeLayer, IPQValueDatePrice
     }
 
     protected string PQValueDatePriceVolumeLayerToStringMembers => $"{PQPriceVolumeLayerToStringMembers}, {nameof(ValueDate)}: {ValueDate}";
+    public override LayerType LayerType => LayerType.ValueDatePriceVolume;
+
+    public override LayerFlags SupportsLayerFlags => LayerFlags.ValueDate | base.SupportsLayerFlags;
 
     public DateTime ValueDate
     {

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel0Quote.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel0Quote.cs
@@ -68,6 +68,8 @@ public class PQLevel0Quote : ReusableObject<ILevel0Quote>, IPQLevel0Quote
         $"{nameof(IsSinglePriceUpdated)}: {IsSinglePriceUpdated}, {nameof(IsReplay)}: {IsReplay}, " +
         $"{nameof(IsReplayUpdated)}: {IsReplayUpdated}, {nameof(HasUpdates)}: {HasUpdates}";
 
+    public virtual QuoteLevel QuoteLevel => QuoteLevel.Level0;
+
     public PQMessageFlags? OverrideSerializationFlags { get; set; }
 
     public uint MessageId => (uint)PQMessageIds.Quote;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel1Quote.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel1Quote.cs
@@ -170,6 +170,8 @@ public class PQLevel1Quote : PQLevel0Quote, IPQLevel1Quote
         $"{nameof(AskPriceTop)}: {AskPriceTop}, {nameof(IsAskPriceTopUpdated)}: {IsAskPriceTopUpdated}, " +
         $"{nameof(Executable)}: {Executable}";
 
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level1;
+
     public override DateTime SourceTime
     {
         get =>

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2Quote.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2Quote.cs
@@ -56,6 +56,8 @@ public class PQLevel2Quote : PQLevel1Quote, IPQLevel2Quote
     protected string Level2ToStringMembers =>
         $"{base.ToString()}, {nameof(IsBidBookChanged)}: {IsBidBookChanged}, {nameof(IsAskBookChanged)}: {IsAskBookChanged}, {nameof(BidBook)}: {BidBook}, {nameof(AskBook)}: {AskBook}, {nameof(BidPriceTop)}: {BidPriceTop}, {nameof(AskPriceTop)}: {AskPriceTop}";
 
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level2;
+
     public bool IsBidBookChanged
     {
         get => bidBook.HasUpdates;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3Quote.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3Quote.cs
@@ -56,6 +56,8 @@ public class PQLevel3Quote : PQLevel2Quote, IPQLevel3Quote
         $"{nameof(IsSourceQuoteReferenceUpdated)}: {IsSourceQuoteReferenceUpdated}, {nameof(ValueDate)}: {ValueDate}, " +
         $"{nameof(IsValueDateUpdated)}: {IsValueDateUpdated}, {nameof(RecentlyTraded)}: {RecentlyTraded}";
 
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level3;
+
     public uint BatchId
     {
         get => batchId;

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/SourceTickerInfoUpdatedFlags.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/SourceTickerInfoUpdatedFlags.cs
@@ -7,12 +7,13 @@ public enum SourceTickerInfoUpdatedFlags : uint
     , SourceTickerId = 0x0001
     , SourceName = 0x0002
     , TickerName = 0x0004
-    , RoundingPrecision = 0x0008
-    , MinSubmitSize = 0x0010
-    , MaxSubmitSize = 0x0020
-    , IncrementSize = 0x0040
-    , MinimumQuoteLife = 0x0080
-    , LayerFlags = 0x0100
-    , MaximumPublishedLayers = 0x0200
-    , LastTradedFlags = 0x0400
+    , PublishedQuoteLevel = 0x0008
+    , RoundingPrecision = 0x0010
+    , MinSubmitSize = 0x0020
+    , MaxSubmitSize = 0x0040
+    , IncrementSize = 0x0080
+    , MinimumQuoteLife = 0x0100
+    , LayerFlags = 0x0200
+    , MaximumPublishedLayers = 0x0400
+    , LastTradedFlags = 0x0800
 }

--- a/src/FortitudeMarketsCore/Pricing/PQ/Publication/BusRules/PQPricingServerRule.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Publication/BusRules/PQPricingServerRule.cs
@@ -1,0 +1,12 @@
+﻿#region
+
+using FortitudeMarketsApi.Configuration.ClientServerConfig;
+
+#endregion
+
+namespace FortitudeMarketsCore.Pricing.PQ.Publication.BusRules;
+
+public class PQPricingServerRule
+{
+    public PQPricingServerRule(IMarketConnectionConfig marketConnectionConfig) { }
+}

--- a/src/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQSourceTickerInfoResponseDeserializer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQSourceTickerInfoResponseDeserializer.cs
@@ -7,6 +7,7 @@ using FortitudeIO.Protocols.Serdes.Binary;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages;
 
 #endregion
@@ -63,6 +64,7 @@ public class PQSourceTickerInfoResponseDeserializer : MessageDeserializer<PQSour
         var deserializedSourceTickerQuoteInfo = recycler.Borrow<SourceTickerQuoteInfo>();
         deserializedSourceTickerQuoteInfo.SourceId = StreamByteOps.ToUShort(ref currPtr);
         deserializedSourceTickerQuoteInfo.TickerId = StreamByteOps.ToUShort(ref currPtr);
+        deserializedSourceTickerQuoteInfo.PublishedQuoteLevel = (QuoteLevel)(*currPtr++);
         deserializedSourceTickerQuoteInfo.RoundingPrecision = StreamByteOps.ToDecimal(ref currPtr);
         deserializedSourceTickerQuoteInfo.MinSubmitSize = StreamByteOps.ToDecimal(ref currPtr);
         deserializedSourceTickerQuoteInfo.MaxSubmitSize = StreamByteOps.ToDecimal(ref currPtr);

--- a/src/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQSourceTickerInfoResponseSerializer.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQSourceTickerInfoResponseSerializer.cs
@@ -81,6 +81,7 @@ internal class PQSourceTickerInfoResponseSerializer : IMessageSerializer<PQSourc
         var writeStart = currPtr;
         StreamByteOps.ToBytes(ref currPtr, sourceTickerQuoteInfo.SourceId);
         StreamByteOps.ToBytes(ref currPtr, sourceTickerQuoteInfo.TickerId);
+        *currPtr++ = (byte)sourceTickerQuoteInfo.PublishedQuoteLevel;
         StreamByteOps.ToBytes(ref currPtr, sourceTickerQuoteInfo.RoundingPrecision);
         StreamByteOps.ToBytes(ref currPtr, sourceTickerQuoteInfo.MinSubmitSize);
         StreamByteOps.ToBytes(ref currPtr, sourceTickerQuoteInfo.MaxSubmitSize);

--- a/src/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQStandaloneUpdateClient.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQStandaloneUpdateClient.cs
@@ -12,7 +12,7 @@ using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
 
 #endregion
 
-namespace FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 public interface IPQUpdateClient : IConversationSubscriber
 {

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastPaidGivenTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastPaidGivenTrade.cs
@@ -3,7 +3,6 @@
 using FortitudeCommon.Types;
 using FortitudeMarketsApi.Pricing.LastTraded;
 
-
 #endregion
 
 namespace FortitudeMarketsCore.Pricing.Quotes.LastTraded;
@@ -29,6 +28,11 @@ public class LastPaidGivenTrade : LastTrade, IMutableLastPaidGivenTrade
             TradeVolume = lastPaidGivenTrade.TradeVolume;
         }
     }
+
+    public override LastTradeType LastTradeType => LastTradeType.PricePaidOrGivenVolume;
+
+    public override LastTradedFlags SupportsLastTradedFlags =>
+        LastTradedFlags.PaidOrGiven | LastTradedFlags.LastTradedVolume | base.SupportsLastTradedFlags;
 
     public bool WasPaid { get; set; }
     public bool WasGiven { get; set; }
@@ -74,17 +78,16 @@ public class LastPaidGivenTrade : LastTrade, IMutableLastPaidGivenTrade
         return baseSame && wasPaidSame && wasGivenSame && tradeVolumeSame;
     }
 
-    public override bool Equals(object? obj) =>
-        ReferenceEquals(this, obj) || AreEquivalent(obj as ILastPaidGivenTrade, true);
+    public override bool Equals(object? obj) => ReferenceEquals(this, obj) || AreEquivalent(obj as ILastPaidGivenTrade, true);
 
     public override int GetHashCode()
     {
         unchecked
         {
             var hashCode = base.GetHashCode();
-            hashCode = hashCode * 397 ^ WasPaid.GetHashCode();
-            hashCode = hashCode * 397 ^ WasGiven.GetHashCode();
-            hashCode = hashCode * 397 ^ TradeVolume.GetHashCode();
+            hashCode = (hashCode * 397) ^ WasPaid.GetHashCode();
+            hashCode = (hashCode * 397) ^ WasGiven.GetHashCode();
+            hashCode = (hashCode * 397) ^ TradeVolume.GetHashCode();
             return hashCode;
         }
     }

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastTrade.cs
@@ -27,6 +27,9 @@ public class LastTrade : ReusableObject<ILastTrade>, IMutableLastTrade
         TradePrice = toClone.TradePrice;
     }
 
+    public virtual LastTradeType LastTradeType => LastTradeType.Price;
+    public virtual LastTradedFlags SupportsLastTradedFlags => LastTradedFlags.LastTradedPrice | LastTradedFlags.LastTradedTime;
+
     public DateTime TradeTime { get; set; }
 
     public virtual decimal TradePrice { get; set; }
@@ -47,8 +50,7 @@ public class LastTrade : ReusableObject<ILastTrade>, IMutableLastTrade
         return this;
     }
 
-    public override IMutableLastTrade Clone() =>
-        (LastTrade?)Recycler?.Borrow<LastTrade>().CopyFrom(this) ?? new LastTrade(this);
+    public override IMutableLastTrade Clone() => (LastTrade?)Recycler?.Borrow<LastTrade>().CopyFrom(this) ?? new LastTrade(this);
 
     object ICloneable.Clone() => Clone();
 
@@ -71,7 +73,7 @@ public class LastTrade : ReusableObject<ILastTrade>, IMutableLastTrade
     {
         unchecked
         {
-            return TradeTime.GetHashCode() * 397 ^ TradePrice.GetHashCode();
+            return (TradeTime.GetHashCode() * 397) ^ TradePrice.GetHashCode();
         }
     }
 

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastTraderPaidGivenTrade.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/LastTraderPaidGivenTrade.cs
@@ -22,6 +22,9 @@ public class LastTraderPaidGivenTrade : LastPaidGivenTrade, IMutableLastTraderPa
             TraderName = lastTraderPaidGivenTrade.TraderName;
     }
 
+    public override LastTradeType LastTradeType => LastTradeType.PriceLastTraderPaidOrGivenVolume;
+    public override LastTradedFlags SupportsLastTradedFlags => LastTradedFlags.TraderName | base.SupportsLastTradedFlags;
+
     public string? TraderName { get; set; }
     public override bool IsEmpty => base.IsEmpty && TraderName == null;
 
@@ -46,8 +49,7 @@ public class LastTraderPaidGivenTrade : LastPaidGivenTrade, IMutableLastTraderPa
 
     ILastTraderPaidGivenTrade ILastTraderPaidGivenTrade.Clone() => (ILastTraderPaidGivenTrade)Clone();
 
-    IMutableLastTraderPaidGivenTrade IMutableLastTraderPaidGivenTrade.Clone() =>
-        (IMutableLastTraderPaidGivenTrade)Clone();
+    IMutableLastTraderPaidGivenTrade IMutableLastTraderPaidGivenTrade.Clone() => (IMutableLastTraderPaidGivenTrade)Clone();
 
     public override bool AreEquivalent(ILastTrade? other, bool exactTypes = false)
     {
@@ -65,7 +67,7 @@ public class LastTraderPaidGivenTrade : LastPaidGivenTrade, IMutableLastTraderPa
     {
         unchecked
         {
-            return base.GetHashCode() * 397 ^ (TraderName?.GetHashCode() ?? 0);
+            return (base.GetHashCode() * 397) ^ (TraderName?.GetHashCode() ?? 0);
         }
     }
 

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/RecentlyTraded.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LastTraded/RecentlyTraded.cs
@@ -32,6 +32,8 @@ public class RecentlyTraded : ReusableObject<IRecentlyTraded>, IMutableRecentlyT
 
     public RecentlyTraded(ISourceTickerQuoteInfo sourceTickerQuoteInfo)
     {
+        LastTradesSupportFlags = sourceTickerQuoteInfo.LastTradedFlags;
+        LastTradesOfType = LastTradesSupportFlags.MostCompactLayerType();
         LastTrades = new List<IMutableLastTrade?>(PQFieldKeys.SingleByteFieldIdMaxPossibleLastTrades);
         for (var i = 0; i < PQFieldKeys.SingleByteFieldIdMaxPossibleLastTrades; i++)
             LastTrades.Add(LastTradeEntrySelector.FindForLastTradeFlags(sourceTickerQuoteInfo));
@@ -39,6 +41,10 @@ public class RecentlyTraded : ReusableObject<IRecentlyTraded>, IMutableRecentlyT
 
     public static ILastTradeEntryFlagsSelector<IMutableLastTrade, ISourceTickerQuoteInfo>
         LastTradeEntrySelector { get; set; } = new RecentlyTradedLastTradeEntrySelector();
+
+    public LastTradeType LastTradesOfType { get; }
+
+    public LastTradedFlags LastTradesSupportFlags { get; }
 
     public bool HasLastTrades => LastTrades.Any(lt => lt?.TradePrice != null);
 

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/OrderBook.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/OrderBook.cs
@@ -22,7 +22,7 @@ public class OrderBook : ReusableObject<IOrderBook>, IMutableOrderBook
         BookLayers = new List<IPriceVolumeLayer?>();
     }
 
-    public OrderBook(BookSide bookSide)
+    public OrderBook(BookSide bookSide, LayerType? layerType = LayerType.PriceVolume)
     {
         BookSide = bookSide;
         BookLayers = new List<IPriceVolumeLayer?>();
@@ -52,8 +52,11 @@ public class OrderBook : ReusableObject<IOrderBook>, IMutableOrderBook
         Capacity = toClone.Capacity;
     }
 
-    public OrderBook(ISourceTickerQuoteInfo sourceTickerQuoteInfo)
+    public OrderBook(BookSide bookSide, ISourceTickerQuoteInfo sourceTickerQuoteInfo)
     {
+        BookSide = bookSide;
+        LayersSupportsLayerFlags = sourceTickerQuoteInfo.LayerFlags;
+        LayersOfType = LayersSupportsLayerFlags.MostCompactLayerType();
         BookLayers = new List<IPriceVolumeLayer?>(sourceTickerQuoteInfo.MaximumPublishedLayers);
         for (var i = 0; i < sourceTickerQuoteInfo.MaximumPublishedLayers; i++)
             BookLayers.Add(LayerSelector.FindForLayerFlags(sourceTickerQuoteInfo));
@@ -61,6 +64,10 @@ public class OrderBook : ReusableObject<IOrderBook>, IMutableOrderBook
 
     public static ILayerFlagsSelector<IPriceVolumeLayer, ISourceTickerQuoteInfo> LayerSelector { get; set; } =
         new OrderBookLayerFactorySelector();
+
+    public LayerType LayersOfType { get; } = LayerType.PriceVolume;
+
+    public LayerFlags LayersSupportsLayerFlags { get; } = LayerFlags.Price | LayerFlags.Volume;
 
     public IMutablePriceVolumeLayer? this[int level]
     {

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/PriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/PriceVolumeLayer.cs
@@ -28,6 +28,9 @@ public class PriceVolumeLayer : ReusableObject<IPriceVolumeLayer>, IMutablePrice
     public decimal Volume { get; set; }
     public virtual bool IsEmpty => Price == 0m && Volume == 0m;
 
+    public virtual LayerType LayerType => LayerType.PriceVolume;
+    public virtual LayerFlags SupportsLayerFlags => LayerFlags.Price | LayerFlags.Volume;
+
     public override void StateReset()
     {
         Price = Volume = 0m;

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourcePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourcePriceVolumeLayer.cs
@@ -28,6 +28,9 @@ public class SourcePriceVolumeLayer : PriceVolumeLayer, IMutableSourcePriceVolum
         }
     }
 
+    public override LayerType LayerType => LayerType.SourcePriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.SourceName | LayerFlags.Executable | base.SupportsLayerFlags;
+
     public string? SourceName { get; set; }
 
     public bool Executable { get; set; }

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourceQuoteRefPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourceQuoteRefPriceVolumeLayer.cs
@@ -22,6 +22,9 @@ public class SourceQuoteRefPriceVolumeLayer : SourcePriceVolumeLayer, IMutableSo
             SourceQuoteReference = srcQtRefPvLayer.SourceQuoteReference;
     }
 
+    public override LayerType LayerType => LayerType.SourceQuoteRefPriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.SourceQuoteReference | base.SupportsLayerFlags;
+
     public uint SourceQuoteReference { get; set; }
     public override bool IsEmpty => base.IsEmpty && SourceQuoteReference == 0u;
 

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourceQuoteRefTraderValueDatePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/SourceQuoteRefTraderValueDatePriceVolumeLayer.cs
@@ -50,6 +50,12 @@ public class SourceQuoteRefTraderValueDatePriceVolumeLayer : TraderPriceVolumeLa
         }
     }
 
+    public override LayerType LayerType => LayerType.SourceQuoteRefTraderValueDatePriceVolume;
+
+    public override LayerFlags SupportsLayerFlags =>
+        LayerFlags.SourceQuoteReference | LayerFlags.SourceName
+                                        | LayerFlags.Executable | LayerFlags.ValueDate | base.SupportsLayerFlags;
+
     public string? SourceName { get; set; }
     public bool Executable { get; set; }
     public DateTime ValueDate { get; set; }

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/TraderPriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/TraderPriceVolumeLayer.cs
@@ -35,6 +35,8 @@ public class TraderPriceVolumeLayer : PriceVolumeLayer, IMutableTraderPriceVolum
     }
 
     protected IList<IMutableTraderLayerInfo?> TraderDetails { get; }
+    public override LayerType LayerType => LayerType.TraderPriceVolume;
+    public override LayerFlags SupportsLayerFlags => LayerFlags.TraderName | LayerFlags.TraderCount | LayerFlags.TraderSize | base.SupportsLayerFlags;
 
     public IMutableTraderLayerInfo? this[int i]
     {

--- a/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/ValueDatePriceVolumeLayer.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/ValueDatePriceVolumeLayer.cs
@@ -24,6 +24,10 @@ public class ValueDatePriceVolumeLayer : PriceVolumeLayer, IMutableValueDatePric
             ValueDate = DateTimeConstants.UnixEpoch;
     }
 
+    public override LayerType LayerType => LayerType.ValueDatePriceVolume;
+
+    public override LayerFlags SupportsLayerFlags => LayerFlags.ValueDate | base.SupportsLayerFlags;
+
     public DateTime ValueDate { get; set; }
     public override bool IsEmpty => base.IsEmpty && ValueDate == DateTimeConstants.UnixEpoch;
 

--- a/src/FortitudeMarketsCore/Pricing/Quotes/Level0PriceQuote.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/Level0PriceQuote.cs
@@ -42,6 +42,8 @@ public class Level0PriceQuote : ReusableObject<ILevel0Quote>, IMutableLevel0Quot
         ClientReceivedTime = toClone.ClientReceivedTime;
     }
 
+    public virtual QuoteLevel QuoteLevel => QuoteLevel.Level0;
+
     public ISourceTickerQuoteInfo? SourceTickerQuoteInfo { get; set; }
     ISourceTickerQuoteInfo? ILevel0Quote.SourceTickerQuoteInfo => SourceTickerQuoteInfo;
     public virtual DateTime SourceTime { get; set; }

--- a/src/FortitudeMarketsCore/Pricing/Quotes/Level1PriceQuote.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/Level1PriceQuote.cs
@@ -63,6 +63,7 @@ public class Level1PriceQuote : Level0PriceQuote, IMutableLevel1Quote
         }
     }
 
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level1;
     public DateTime AdapterReceivedTime { get; set; } = DateTimeConstants.UnixEpoch;
     public DateTime AdapterSentTime { get; set; } = DateTimeConstants.UnixEpoch;
     public DateTime SourceBidTime { get; set; } = DateTimeConstants.UnixEpoch;

--- a/src/FortitudeMarketsCore/Pricing/Quotes/Level2PriceQuote.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/Level2PriceQuote.cs
@@ -33,12 +33,12 @@ public class Level2PriceQuote : Level1PriceQuote, IMutableLevel2Quote
         if (bidBook is OrderBook mutBidOrderBook)
             BidBook = mutBidOrderBook;
         else
-            BidBook = bidBook != null ? new OrderBook(bidBook) : new OrderBook(SourceTickerQuoteInfo!);
+            BidBook = bidBook != null ? new OrderBook(bidBook) : new OrderBook(BookSide.BidBook, SourceTickerQuoteInfo!);
         IsBidBookChanged = isBidBookChanged;
         if (askBook is OrderBook mutAskOrderBook)
             AskBook = mutAskOrderBook;
         else
-            AskBook = askBook != null ? new OrderBook(askBook) : new OrderBook(SourceTickerQuoteInfo!);
+            AskBook = askBook != null ? new OrderBook(askBook) : new OrderBook(BookSide.AskBook, SourceTickerQuoteInfo!);
         IsAskBookChanged = isAskBookChanged;
     }
 
@@ -66,6 +66,8 @@ public class Level2PriceQuote : Level1PriceQuote, IMutableLevel2Quote
             AskBook = new OrderBook(BookSide.AskBook, 20);
         }
     }
+
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level2;
 
     public IMutableOrderBook BidBook { get; set; }
     IOrderBook ILevel2Quote.BidBook => BidBook;

--- a/src/FortitudeMarketsCore/Pricing/Quotes/Level3PriceQuote.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/Level3PriceQuote.cs
@@ -54,6 +54,8 @@ public class Level3PriceQuote : Level2PriceQuote, IMutableLevel3Quote
         }
     }
 
+    public override QuoteLevel QuoteLevel => QuoteLevel.Level3;
+
     public IMutableRecentlyTraded? RecentlyTraded { get; set; }
 
     IRecentlyTraded? ILevel3Quote.RecentlyTraded => RecentlyTraded;

--- a/src/FortitudeTests/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfoTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfoTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 
 #endregion
 
@@ -15,11 +16,10 @@ public class SourceTickerQuoteInfoTests
     private SourceTickerQuoteInfo sourceTickerQuoteInfo = null!;
 
     public static SourceTickerQuoteInfo DummySourceTickerQuoteInfo =>
-        new(1, "TestSource", 1, "TestTicker", 10,
-            0.00001m, 30_000m, 10_000_000m, 10_000m, 250, LayerFlags.Price | LayerFlags.Volume |
-                                                          LayerFlags.SourceName, LastTradedFlags.LastTradedPrice |
-                                                                                 LastTradedFlags.LastTradedTime |
-                                                                                 LastTradedFlags.LastTradedVolume);
+        new(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 10,
+            0.00001m, 30_000m, 10_000_000m, 10_000m, 250,
+            LayerFlags.Price | LayerFlags.Volume | LayerFlags.SourceName,
+            LastTradedFlags.LastTradedPrice | LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedVolume);
 
     [TestInitialize]
     public void SetUp()
@@ -33,7 +33,7 @@ public class SourceTickerQuoteInfoTests
         ushort srcId = 123;
         ushort tkrId = 234;
 
-        var firstUniSrcTkrId = new SourceTickerQuoteInfo(srcId, "TestSource", tkrId, "TestTicker");
+        var firstUniSrcTkrId = new SourceTickerQuoteInfo(srcId, "TestSource", tkrId, "TestTicker", QuoteLevel.Level2);
 
         expectedId = ((uint)srcId << 16) + tkrId;
 
@@ -41,7 +41,7 @@ public class SourceTickerQuoteInfoTests
         Assert.AreEqual("TestTicker", firstUniSrcTkrId.Ticker);
         Assert.AreEqual("TestSource", firstUniSrcTkrId.Source);
 
-        var secondUniSrcTkrId = new SourceTickerQuoteInfo(srcId, "TestSource", tkrId, "TestTicker");
+        var secondUniSrcTkrId = new SourceTickerQuoteInfo(srcId, "TestSource", tkrId, "TestTicker", QuoteLevel.Level2);
         Assert.AreEqual(firstUniSrcTkrId, secondUniSrcTkrId);
     }
 
@@ -67,7 +67,7 @@ public class SourceTickerQuoteInfoTests
     [TestMethod]
     public void EmptySourceTickerQuoteInfo_New_DefaultAreAsExpected()
     {
-        var minimalSrcTkrQtInfo = new SourceTickerQuoteInfo(1, "MinimalSource", 1, "MinalTicker");
+        var minimalSrcTkrQtInfo = new SourceTickerQuoteInfo(1, "MinimalSource", 1, "MinalTicker", QuoteLevel.Level2);
 
         expectedId = ((uint)minimalSrcTkrQtInfo.SourceId << 16) + minimalSrcTkrQtInfo.TickerId;
         Assert.AreEqual(expectedId, minimalSrcTkrQtInfo.Id);
@@ -89,7 +89,7 @@ public class SourceTickerQuoteInfoTests
         var formatPriceString = sourceTickerQuoteInfo.FormatPrice;
         Assert.AreEqual("0.00000", formatPriceString);
 
-        var twoDecimalPrecision = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 10, 0.01m);
+        var twoDecimalPrecision = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 10, 0.01m);
         formatPriceString = twoDecimalPrecision.FormatPrice;
         Assert.AreEqual("0.00", formatPriceString);
     }
@@ -113,9 +113,9 @@ public class SourceTickerQuoteInfoTests
     [TestMethod]
     public void NonExactUniqueSourceTickerId_AreEquivalent_EquivalentWhenSamePartsSame()
     {
-        var commonStqi = new SourceTickerQuoteInfo(12345, "TestSource", 12345, "TestTicker");
+        var commonStqi = new SourceTickerQuoteInfo(12345, "TestSource", 12345, "TestTicker", QuoteLevel.Level2);
 
-        var nonStqi = new SourceTickerQuoteInfo(12345, "TestSource", 12345, "TestTicker");
+        var nonStqi = new SourceTickerQuoteInfo(12345, "TestSource", 12345, "TestTicker", QuoteLevel.Level2);
 
         Assert.IsTrue(commonStqi.AreEquivalent(nonStqi));
     }
@@ -123,51 +123,51 @@ public class SourceTickerQuoteInfoTests
     [TestMethod]
     public void OneDifferenceAtATime_AreEquivalent_ReturnsFalseWhenDifferent()
     {
-        var commonStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker");
+        var commonStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2);
 
-        var sourceIdDiffStqi = new SourceTickerQuoteInfo(2, "TestSource", 1, "TestTicker");
+        var sourceIdDiffStqi = new SourceTickerQuoteInfo(2, "TestSource", 1, "TestTicker", QuoteLevel.Level2);
         Assert.AreNotEqual(commonStqi, sourceIdDiffStqi);
 
-        var tickerIdDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 2, "TestTicker");
+        var tickerIdDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 2, "TestTicker", QuoteLevel.Level2);
         Assert.AreNotEqual(commonStqi, tickerIdDiffStqi);
 
-        var srcDiffStqi = new SourceTickerQuoteInfo(1, "DiffSource", 1, "TestTicker");
+        var srcDiffStqi = new SourceTickerQuoteInfo(1, "DiffSource", 1, "TestTicker", QuoteLevel.Level2);
         Assert.AreNotEqual(commonStqi, srcDiffStqi);
 
-        var tkrDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "DiffTicker");
+        var tkrDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "DiffTicker", QuoteLevel.Level2);
         Assert.AreNotEqual(commonStqi, tkrDiffStqi);
 
-        var numLayersDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 4);
+        var numLayersDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 4);
         Assert.AreNotEqual(commonStqi, numLayersDiffStqi);
 
-        var roundingPrecisionDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.01m);
+        var roundingPrecisionDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.01m);
         Assert.AreNotEqual(commonStqi, roundingPrecisionDiffStqi);
 
-        var minSubSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 1m);
+        var minSubSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 1m);
         Assert.AreNotEqual(commonStqi, minSubSizeDiffStqi);
 
-        var maxSubSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var maxSubSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000_000);
         Assert.AreNotEqual(commonStqi, maxSubSizeDiffStqi);
 
-        var incrementSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var incrementSizeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000, 1m);
         Assert.AreNotEqual(commonStqi, incrementSizeDiffStqi);
 
-        var minQuoteLifeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var minQuoteLifeDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000, 0.01m, 250);
         Assert.AreNotEqual(commonStqi, minQuoteLifeDiffStqi);
 
-        var layerFlagsDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var layerFlagsDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000, 0.01m, 100, LayerFlags.SourceQuoteReference | LayerFlags.ValueDate);
         Assert.AreNotEqual(commonStqi, layerFlagsDiffStqi);
 
-        var lastTradeFlagsDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var lastTradeFlagsDiffStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000, 0.01m, 100, LayerFlags.Price | LayerFlags.Volume, LastTradedFlags.TraderName);
         Assert.AreNotEqual(commonStqi, lastTradeFlagsDiffStqi);
 
         // ReSharper disable RedundantArgumentDefaultValue
-        var matchingStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", 20, 0.0001m, 0.01m,
+        var matchingStqi = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, 20, 0.0001m, 0.01m,
             1_000_000, 0.01m, 100, LayerFlags.Price | LayerFlags.Volume, LastTradedFlags.None);
         Assert.AreEqual(commonStqi, matchingStqi);
         // ReSharper restore RedundantArgumentDefaultValue
@@ -176,7 +176,7 @@ public class SourceTickerQuoteInfoTests
     [TestMethod]
     public void PopulatedSti_GetHashCode_NotEqualTo0()
     {
-        var firstSrcTkrQuoteInfo = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker");
+        var firstSrcTkrQuoteInfo = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2);
 
         Assert.AreNotEqual(0, firstSrcTkrQuoteInfo.GetHashCode());
     }
@@ -184,7 +184,7 @@ public class SourceTickerQuoteInfoTests
     [TestMethod]
     public void FullyPopulatedSti_ToString_ReturnsNameAndValues()
     {
-        var srcTkrQtInfo = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker");
+        var srcTkrQtInfo = new SourceTickerQuoteInfo(1, "TestSource", 1, "TestTicker", QuoteLevel.Level2);
         var toString = srcTkrQtInfo.ToString();
 
         Assert.IsTrue(toString.Contains(srcTkrQtInfo.GetType().Name));

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Conflation/PQPeriodSummaryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Conflation/PQPeriodSummaryTests.cs
@@ -7,6 +7,7 @@ using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.Conflation;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.Conflation;
 using FortitudeMarketsCore.Pricing.PQ.Conflation;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
@@ -34,11 +35,10 @@ public class PQPeriodSummaryTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         pricePrecisionSettings = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(
-            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
-            LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
-            | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
-                                                                  | LastTradedFlags.LastTradedVolume |
-                                                                  LastTradedFlags.LastTradedTime)
+            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20,
+            0.00001m, 30000m, 50000000m, 1000m, 1,
+            LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize | LayerFlags.TraderCount,
+            LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime)
         );
 
         emptySummary = new PQPeriodSummary();

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/LastTradeEntrySelector/PQLastTradeEntrySelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LastTraded/LastTradeEntrySelector/PQLastTradeEntrySelectorTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DictionaryCompression;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.LastTraded;
@@ -53,7 +54,7 @@ public class PQLastTradeEntrySelectorTests
         pqTraderPaidGivenLastTrade = new PQLastTraderPaidGivenTrade(traderNameIdGenerator, ExpectedPrice, expectedTradeTime,
             ExpectedVolume, true, true, expectedTradeName);
         pqSourceTickerQuoteInfo = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime));
         pqSourceTickerQuoteInfo.NameIdLookup = traderNameIdGenerator;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/LayerSelector/PQOrderBookLayerFactorySelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/LayerSelector/PQOrderBookLayerFactorySelectorTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DictionaryCompression;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.LayeredBook;
@@ -88,7 +89,7 @@ public class PQOrderBookLayerFactorySelectorTests
 
 
         pqSourceTickerQuoteInfo = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime));
         pqSourceTickerQuoteInfo.NameIdLookup = nameIdGenerator;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBookTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBookTests.cs
@@ -5,6 +5,7 @@ using FortitudeCommon.Types;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DictionaryCompression;
@@ -100,7 +101,7 @@ public class PQOrderBookTests
             , valueDateFullyPopulatedOrderBook, traderFullyPopulatedOrderBook, allFieldsFullyPopulatedOrderBook
         };
         publicationPrecisionSettings = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(
-            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", MaxNumberOfLayers, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, MaxNumberOfLayers, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime));
     }
@@ -172,34 +173,34 @@ public class PQOrderBookTests
     [TestMethod]
     public void PQOrderBook_InitializedFromOrderBook_ConvertsLayers()
     {
-        var nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        var nonPqOrderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         var pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQPriceVolumeLayer));
 
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.SourceName | LayerFlags.Executable;
-        nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        nonPqOrderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQSourcePriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.SourceName | LayerFlags.Executable |
                                                   LayerFlags.SourceQuoteReference;
-        nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        nonPqOrderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQSourceQuoteRefPriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.ValueDate;
-        nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        nonPqOrderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQValueDatePriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.TraderName | LayerFlags.TraderCount |
                                                   LayerFlags.TraderSize;
-        nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        nonPqOrderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQTraderPriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price.AllFlags();
-        nonPqOrderBook = new OrderBook(publicationPrecisionSettings);
+        nonPqOrderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         pqorderBook = new PQOrderBook(nonPqOrderBook);
         AssertBookHasLayersOfType(pqorderBook, typeof(PQSourceQuoteRefTraderValueDatePriceVolumeLayer));
     }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQImplementationFactoryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQImplementationFactoryTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 
 #endregion
@@ -16,7 +17,7 @@ public class PQImplementationFactoryTests
     public void NewPQImplementationFactory_GetConcreteMapping_GetsConcreateImplementationOfInterface()
     {
         var sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
@@ -40,7 +41,7 @@ public class PQImplementationFactoryTests
     public void NonSupportedPQType_GetConcreteMapping_GetsConcreateImplementationOfInterface()
     {
         var sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel0QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel0QuoteTests.cs
@@ -40,12 +40,12 @@ public class PQLevel0QuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime);
-        blankSourceTickerQuoteInfo = new SourceTickerQuoteInfo(0, "", 0, "");
+        blankSourceTickerQuoteInfo = new SourceTickerQuoteInfo(0, "", 0, "", QuoteLevel.Level1);
         emptyQuote = new PQLevel0Quote(sourceTickerQuoteInfo) { HasUpdates = false };
         fullyPopulatedPqLevel0Quote = new PQLevel0Quote(sourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(fullyPopulatedPqLevel0Quote, 1);
@@ -524,6 +524,7 @@ public class PQLevel0QuoteTests
         public uint MessageId => (uint)PQMessageIds.Quote;
         public byte Version => 1;
         public uint PQSequenceId { get; set; }
+        public virtual QuoteLevel QuoteLevel => QuoteLevel.Level0;
         public ISyncLock Lock { get; } = new SpinLockLight();
         public IPQLevel0Quote? Previous { get; set; }
         public IPQLevel0Quote? Next { get; set; }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel1QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel1QuoteTests.cs
@@ -37,12 +37,12 @@ public class PQLevel1QuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime);
-        blankSourceTickerQuoteInfo = new SourceTickerQuoteInfo(0, "", 0, "");
+        blankSourceTickerQuoteInfo = new SourceTickerQuoteInfo(0, "", 0, "", QuoteLevel.Level1);
         emptyQuote = new PQLevel1Quote(sourceTickerQuoteInfo) { HasUpdates = false };
         fullyPopulatedPqLevel1Quote = new PQLevel1Quote(sourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(fullyPopulatedPqLevel1Quote, 1);
@@ -708,6 +708,8 @@ public class PQLevel1QuoteTests
 
     internal class DummyLevel1Quote : PQLevel0QuoteTests.DummyPQLevel0Quote, IPQLevel1Quote
     {
+        public override QuoteLevel QuoteLevel => QuoteLevel.Level1;
+
         IMutablePeriodSummary? IMutableLevel1Quote.PeriodSummary
         {
             get => PeriodSummary;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2QuoteTests.cs
@@ -55,33 +55,33 @@ public class PQLevel2QuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         simpleSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         sourceNameSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceName, LastTradedFlags.PaidOrGiven |
                                                                           LastTradedFlags.TraderName |
                                                                           LastTradedFlags.LastTradedVolume |
                                                                           LastTradedFlags.LastTradedTime);
         sourceQuoteRefSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue,
-            "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceQuoteReference, LastTradedFlags.PaidOrGiven |
                                                                                     LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume |
                                                                                     LastTradedFlags.LastTradedTime);
         traderDetailsSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue,
-            "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize |
             LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                     LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         valueDateSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.ValueDate, LastTradedFlags.PaidOrGiven |
                                                                          LastTradedFlags.TraderName |
                                                                          LastTradedFlags.LastTradedVolume |
                                                                          LastTradedFlags.LastTradedTime);
         everyLayerSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume.AllFlags(), LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                           LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         simpleEmptyLevel2Quote = new PQLevel2Quote(simpleSourceTickerQuoteInfo) { HasUpdates = false };
@@ -127,7 +127,7 @@ public class PQLevel2QuoteTests
     public void TooLargeMaxBookDepth_New_CapsBookDepthTo()
     {
         var tooLargeMaxDepth = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 21, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 21, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         var cappedLevel2Quote = new PQLevel2Quote(tooLargeMaxDepth);
@@ -141,7 +141,7 @@ public class PQLevel2QuoteTests
     public void TooSmalMaxBookDepth_New_IncreaseBookDepthAtLeast1Level()
     {
         var tooLargeMaxDepth = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 0, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 0, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         var cappedLevel2Quote = new PQLevel2Quote(tooLargeMaxDepth);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3QuoteTests.cs
@@ -48,23 +48,23 @@ public class PQLevel3QuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         noRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.None);
         simpleRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice);
         paidGivenVolumeRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice | LastTradedFlags.PaidOrGiven |
             LastTradedFlags.LastTradedVolume);
         traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice | LastTradedFlags.TraderName);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/PQSourceTickerQuoteInfoTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/PQSourceTickerQuoteInfoTests.cs
@@ -5,6 +5,7 @@ using FortitudeCommon.Types;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.SourceTickerInfo;
@@ -25,12 +26,12 @@ public class PQSourceTickerQuoteInfoTests
     public void SetUp()
     {
         fullyPopulatedSrcTkrQtInfo = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(
-            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime));
-        emptySrcTkrQtInfo = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(0, "", 0, "", 0, 0m, 0m,
+        emptySrcTkrQtInfo = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(0, "", 0, "", QuoteLevel.Level2, 0, 0m, 0m,
             0m, 0m, 0, LayerFlags.None));
 
         testDateTime = new DateTime(2017, 11, 07, 18, 33, 24);
@@ -488,7 +489,7 @@ public class PQSourceTickerQuoteInfoTests
         fullyPopulatedSrcTkrQtInfo.HasUpdates = true;
         var pqFieldUpdates = fullyPopulatedSrcTkrQtInfo.GetDeltaUpdateFields(
             new DateTime(2017, 11, 04, 16, 33, 59), PQMessageFlags.Update).ToList();
-        var newEmpty = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(0, "", 0, ""));
+        var newEmpty = new PQSourceTickerQuoteInfo(new SourceTickerQuoteInfo(0, "", 0, "", QuoteLevel.Level3));
         foreach (var pqFieldUpdate in pqFieldUpdates) newEmpty.UpdateField(pqFieldUpdate);
         var stringFieldUpdates = fullyPopulatedSrcTkrQtInfo.GetStringUpdates(new DateTime(2017, 11, 04, 16, 33, 59),
             PQMessageFlags.Update);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Publication/PQPublisherTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Publication/PQPublisherTests.cs
@@ -39,9 +39,9 @@ public class PQPublisherTests
         moqMarketConnectionConfig.Setup(stpcr => stpcr.AllSourceTickerInfos)
             .Returns(new List<ISourceTickerQuoteInfo>()
             {
-                new SourceTickerQuoteInfo(1, "First", 1, "First")
-                , new SourceTickerQuoteInfo(1, "First", 2, "Second")
-                , new SourceTickerQuoteInfo(2, "Second", 1, "First")
+                new SourceTickerQuoteInfo(1, "First", 1, "First", QuoteLevel.Level3)
+                , new SourceTickerQuoteInfo(1, "First", 2, "Second", QuoteLevel.Level3)
+                , new SourceTickerQuoteInfo(2, "Second", 1, "First", QuoteLevel.Level3)
             });
 
         pqPublisher.RegisterTickersWithServer(moqMarketConnectionConfig.Object);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQClientMessageStreamDecoderTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQClientMessageStreamDecoderTests.cs
@@ -9,6 +9,7 @@ using FortitudeIO.Protocols.Serdes.Binary.Sockets;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes;
@@ -27,7 +28,7 @@ public class PQClientMessageStreamDecoderTests
     private const ushort ExpectedSourceId = ushort.MaxValue;
     private const ushort ExpectedTickerId = ushort.MaxValue;
     private const uint ExpectedStreamId = uint.MaxValue;
-    private const uint MessageSizeToQuoteSerializer = 130 + PQQuoteMessageHeader.HeaderSize;
+    private const uint MessageSizeToQuoteSerializer = 136 + PQQuoteMessageHeader.HeaderSize;
     private Mock<IPQClientQuoteDeserializerRepository> clientDeserializerRepo = null!;
     private IConversation? lastReceivedConversation;
     private List<ISourceTickerQuoteInfo> lastReceivedSourceTickerQuoteInfos = null!;
@@ -38,13 +39,13 @@ public class PQClientMessageStreamDecoderTests
 
     private List<ISourceTickerQuoteInfo> sendSourceTickerQuoteInfos = new()
     {
-        new SourceTickerQuoteInfo(0x7777, "FirstSource", 3333, "FirstTicker", 7,
+        new SourceTickerQuoteInfo(0x7777, "FirstSource", 3333, "FirstTicker", QuoteLevel.Level3, 7,
             0.000005m, 1m, 10_000_000m, 2m, 1
             , LayerFlags.Price | LayerFlags.ValueDate, LastTradedFlags.LastTradedPrice)
-        , new SourceTickerQuoteInfo(0x5151, "SecondSource", 7777, "SecondTicker", 20,
+        , new SourceTickerQuoteInfo(0x5151, "SecondSource", 7777, "SecondTicker", QuoteLevel.Level3, 20,
             0.05m, 10_000m, 1_000_000m, 5_000m, 2_000
             , LayerFlags.Price | LayerFlags.TraderName | LayerFlags.Executable, LastTradedFlags.PaidOrGiven)
-        , new SourceTickerQuoteInfo(0xFFFF, "ThirdSource", 0001, "ThirdTicker", 1, 5m,
+        , new SourceTickerQuoteInfo(0xFFFF, "ThirdSource", 0001, "ThirdTicker", QuoteLevel.Level3, 1, 5m,
             100_000m, 100_000_000m, 50_000m, 1, LayerFlags.None)
     };
 
@@ -67,7 +68,7 @@ public class PQClientMessageStreamDecoderTests
         };
         readWriteBuffer.ReadCursor = BufferReadWriteOffset;
         readWriteBuffer.WriteCursor = BufferReadWriteOffset;
-        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerId, "TestTicker",
+        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerId, "TestTicker", QuoteLevel.Level3,
             20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price,
             LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
@@ -253,13 +254,13 @@ public class PQClientMessageStreamDecoderTests
 
         sendSourceTickerQuoteInfos = new List<ISourceTickerQuoteInfo>
         {
-            new SourceTickerQuoteInfo(1111, "FourthSource", 5555, "FourthTicker", 7,
+            new SourceTickerQuoteInfo(1111, "FourthSource", 5555, "FourthTicker", QuoteLevel.Level3, 7,
                 0.000005m, 1m, 10_000_000m, 2m, 1
                 , LayerFlags.Price | LayerFlags.ValueDate, LastTradedFlags.LastTradedPrice)
-            , new SourceTickerQuoteInfo(0xAAAA, "FifthSource", 3333, "FifthTicker", 20, 0.05m,
+            , new SourceTickerQuoteInfo(0xAAAA, "FifthSource", 3333, "FifthTicker", QuoteLevel.Level3, 20, 0.05m,
                 10_000m, 1_000_000m, 5_000m, 2_000
                 , LayerFlags.Price | LayerFlags.TraderName | LayerFlags.Executable, LastTradedFlags.PaidOrGiven)
-            , new SourceTickerQuoteInfo(0x2222, "SixthSource", 7777, "SixthTicker", 1, 5m,
+            , new SourceTickerQuoteInfo(0x2222, "SixthSource", 7777, "SixthTicker", QuoteLevel.Level3, 1, 5m,
                 100_000m, 100_000_000m, 50_000m, 1, LayerFlags.None
                 , LastTradedFlags.None)
         };

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQClientQuoteDeserializerRepositoryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQClientQuoteDeserializerRepositoryTests.cs
@@ -5,6 +5,7 @@ using FortitudeIO.Transports.Network.Config;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
 
@@ -25,7 +26,7 @@ public class PQClientQuoteDeserializerRepositoryTests
     [TestInitialize]
     public void SetUp()
     {
-        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerd, "TestTicker", 20,
+        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerd, "TestTicker", QuoteLevel.Level3, 20,
             0.00001m, 30000m, 50000000m, 1000m, 1, LayerFlags.Volume | LayerFlags.Price,
             LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
             LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQDeserializerBaseTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQDeserializerBaseTests.cs
@@ -77,7 +77,7 @@ public class PQDeserializerBaseTests
         readWriteBuffer.ReadCursor = BufferReadWriteOffset;
         readWriteBuffer.WriteCursor = BufferReadWriteOffset;
 
-        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker",
+        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3,
             20, 0.00001m, 30000m, 50000000m, 1000m, 1, LayerFlags.Volume | LayerFlags.Price,
             LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
             LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerTests.cs
@@ -63,7 +63,7 @@ public class PQQuoteDeserializerTests
     public void SetUp()
     {
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteFeedDeserializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteFeedDeserializerTests.cs
@@ -88,7 +88,7 @@ public class PQQuoteFeedDeserializerTests
     }
 
     private SourceTickerQuoteInfo BuildSourceTickerQuoteInfo(ushort sourceId, ushort tickerId, string ticker) =>
-        new(sourceId, "TestSource", tickerId, ticker, 20,
+        new(sourceId, "TestSource", tickerId, ticker, QuoteLevel.Level3, 20,
             0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/SyncState/SyncStateBaseTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/SyncState/SyncStateBaseTests.cs
@@ -78,7 +78,7 @@ public class SyncStateBaseTests
     private void BuildPQQuote()
     {
         SourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQHeartbeatSerializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQHeartbeatSerializerTests.cs
@@ -5,6 +5,7 @@ using FortitudeCommon.Serdes.Binary;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes;
@@ -38,25 +39,25 @@ public class PQHeartbeatSerializerTests
     public void SetUp()
     {
         firstQuoteInfo = new SourceTickerQuoteInfo(1, "TestSource", 1,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime);
         secondQuoteInfo = new SourceTickerQuoteInfo(2, "TestSource", 2,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime);
         thirdQuoteInfo = new SourceTickerQuoteInfo(3, "TestSource", 3,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |
                                                                   LastTradedFlags.LastTradedTime);
         fourthQuoteInfo = new SourceTickerQuoteInfo(4, "TestSource", 4,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerRepositoryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerRepositoryTests.cs
@@ -4,6 +4,7 @@ using FortitudeCommon.DataStructures.Memory;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Serialization;
@@ -23,7 +24,7 @@ public class PQClientQuoteSerializerRepositoryTests
     [TestInitialize]
     public void SetUp()
     {
-        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerd, "TestTicker", 20,
+        sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ExpectedSourceId, "TestSource", ExpectedTickerd, "TestTicker", QuoteLevel.Level3, 20,
             0.00001m, 30000m, 50000000m, 1000m, 1, LayerFlags.Volume | LayerFlags.Price,
             LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
             LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerTests.cs
@@ -10,6 +10,7 @@ using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
@@ -64,26 +65,27 @@ public class PQQuoteSerializerTests
         updateQuoteSerializer = new PQQuoteSerializer(PQMessageFlags.Update);
         snapshotQuoteSerializer = new PQQuoteSerializer(PQMessageFlags.Snapshot);
 
-        level0QuoteInfo = new SourceTickerQuoteInfo(1, "TestSource1", 1, "TestTicker1", 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
-        level1QuoteInfo = new SourceTickerQuoteInfo(2, "TestSource2", 2, "TestTicker2", 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+        level0QuoteInfo = new SourceTickerQuoteInfo(1, "TestSource1", 1, "TestTicker1", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+        level1QuoteInfo = new SourceTickerQuoteInfo(2, "TestSource2", 2, "TestTicker2", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
         valueDateQuoteInfo = new SourceTickerQuoteInfo(7, "TestSource", 7,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.ValueDate
             , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         everyLayerQuoteInfo = new SourceTickerQuoteInfo(8, "TestSource", 8,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume.AllFlags(), LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                           LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
-        simpleNoRecentlyTradedQuoteInfo = new SourceTickerQuoteInfo(3, "TestSource", 3, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+        simpleNoRecentlyTradedQuoteInfo
+            = new SourceTickerQuoteInfo(3, "TestSource", 3, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
         srcNmLstTrdQuoteInfo = new SourceTickerQuoteInfo(4,
-            "TestSource", 4, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestSource", 4, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceName, LastTradedFlags.LastTradedPrice |
                                                                           LastTradedFlags.LastTradedTime);
         srcQtRfPdGvnVlmQuoteInfo = new SourceTickerQuoteInfo(
-            5, "TestSource", 5, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            5, "TestSource", 5, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceQuoteReference, LastTradedFlags.PaidOrGiven);
         trdrLyrTrdrPdGvnVlmDtlsQuoteInfo = new SourceTickerQuoteInfo(
-            6, "TestSource", 6, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            6, "TestSource", 6, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize |
             LayerFlags.TraderCount, LastTradedFlags.TraderName);
         level0Quote = new PQLevel0Quote(level0QuoteInfo);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/LocalHostPQClientTestSetup.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/LocalHostPQClientTestSetup.cs
@@ -3,7 +3,6 @@
 using FortitudeIO.Transports.Network.Dispatcher;
 using FortitudeIO.Transports.Network.Receiving;
 using FortitudeMarketsApi.Configuration.ClientServerConfig;
-using FortitudeMarketsCore.Pricing.PQ.Subscription;
 using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 using FortitudeTests.FortitudeCommon.Types;
 

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQClientSyncMonitoringTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQClientSyncMonitoringTests.cs
@@ -15,7 +15,7 @@ using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQClientSyncMonitoringTests

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQClientTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQClientTests.cs
@@ -8,13 +8,12 @@ using FortitudeMarketsApi.Configuration.ClientServerConfig;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
-using FortitudeMarketsCore.Pricing.PQ.Subscription;
 using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQClientTests

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQConversationRepositoryBaseTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQConversationRepositoryBaseTests.cs
@@ -15,7 +15,7 @@ using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQConversationRepositoryBaseTests
@@ -170,6 +170,9 @@ public class PQConversationRepositoryBaseTests
         public int Id { get; } = 0;
         public IConversationSession Session { get; } = null!;
         public string Name { get; set; } = "";
+
+        public bool IsStarted { get; } = false;
+        public IStreamListener? StreamListener { get; set; }
         public event Action<string, int>? Error;
         public event Action? Started;
         public event Action? Stopped;
@@ -179,8 +182,5 @@ public class PQConversationRepositoryBaseTests
         public void Stop(CloseReason closeReason = CloseReason.Completed, string? reason = null) { }
 
         public void OnSessionFailure(string reason) { }
-
-        public bool IsStarted { get; } = false;
-        public IStreamListener? StreamListener { get; set; }
     }
 }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQSnapshotClientRepositoryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQSnapshotClientRepositoryTests.cs
@@ -13,7 +13,7 @@ using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQSnapshotClientRepositoryTests

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQStandaloneSnapshotClientTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQStandaloneSnapshotClientTests.cs
@@ -20,6 +20,7 @@ using FortitudeIO.Transports.Network.Receiving;
 using FortitudeIO.Transports.Network.Sockets;
 using FortitudeIO.Transports.Network.State;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes;
@@ -155,11 +156,11 @@ public class PQStandaloneSnapshotClientTests
 
         sendSrcTkrIds = new List<ISourceTickerQuoteInfo>
         {
-            new SourceTickerQuoteInfo(7, "FirstSource", 7, "FirstTicker")
-            , new SourceTickerQuoteInfo(77, "FirstSource", 77, "SecondTicker")
-            , new SourceTickerQuoteInfo(15, "FirstSource", 16, "ThirdTicker")
-            , new SourceTickerQuoteInfo(19, "FirstSource", 19, "FourthTicker")
-            , new SourceTickerQuoteInfo(798, "FirstSource", 798, "FifthTicker")
+            new SourceTickerQuoteInfo(7, "FirstSource", 7, "FirstTicker", QuoteLevel.Level3)
+            , new SourceTickerQuoteInfo(77, "FirstSource", 77, "SecondTicker", QuoteLevel.Level3)
+            , new SourceTickerQuoteInfo(15, "FirstSource", 16, "ThirdTicker", QuoteLevel.Level3)
+            , new SourceTickerQuoteInfo(19, "FirstSource", 19, "FourthTicker", QuoteLevel.Level3)
+            , new SourceTickerQuoteInfo(798, "FirstSource", 798, "FifthTicker", QuoteLevel.Level3)
         };
 
         moqSocketBinaryDeserializer.SetupAllProperties();

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQTickerFeedSubscriptionQuoteStreamTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQTickerFeedSubscriptionQuoteStreamTests.cs
@@ -7,13 +7,14 @@ using FortitudeIO.Transports.Network.Config;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQTickerFeedSubscriptionQuoteStreamTests
@@ -43,7 +44,7 @@ public class PQTickerFeedSubscriptionQuoteStreamTests
                 }));
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(
-            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQTickerFeedSubscriptionTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQTickerFeedSubscriptionTests.cs
@@ -4,11 +4,12 @@ using FortitudeIO.Transports.Network.Config;
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQTickerFeedSubscriptionTests
@@ -33,7 +34,7 @@ public class PQTickerFeedSubscriptionTests
         );
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(
-            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQUpdateClientRepositoryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQUpdateClientRepositoryTests.cs
@@ -11,13 +11,12 @@ using FortitudeIO.Transports.Network.Dispatcher;
 using FortitudeIO.Transports.Network.State;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
-using FortitudeMarketsCore.Pricing.PQ.Subscription;
 using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQUpdateClientRepositoryTests
@@ -25,7 +24,7 @@ public class PQUpdateClientRepositoryTests
     private Mock<Action<SocketSessionState>> moqAction = null!;
     private Mock<IFLogger> moqFlogger = null!;
     private Mock<IOSSocket> moqOsSocket = null!;
-    private Mock<IOSParallelController> moqParallelControler = null!;
+    private Mock<IOSParallelController> moqParallelController = null!;
     private Mock<IOSParallelControllerFactory> moqParallelControllerFactory = null!;
     private Mock<IPQClientQuoteDeserializerRepository> moqPQQuoteSerializationRepo = null!;
     private Mock<IEndpointConfig> moqServerConnectionConfig = null!;
@@ -44,10 +43,10 @@ public class PQUpdateClientRepositoryTests
     public void SetUp()
     {
         moqFlogger = new Mock<IFLogger>();
-        moqParallelControler = new Mock<IOSParallelController>();
+        moqParallelController = new Mock<IOSParallelController>();
         moqParallelControllerFactory = new Mock<IOSParallelControllerFactory>();
         moqParallelControllerFactory.SetupGet(pcf => pcf.GetOSParallelController)
-            .Returns(moqParallelControler.Object);
+            .Returns(moqParallelController.Object);
         moqSocketDispatcherResolver = new Mock<ISocketDispatcherResolver>();
         OSParallelControllerFactory.Instance = moqParallelControllerFactory.Object;
         moqSocketTopicConnectionConfig = new Mock<INetworkTopicConnectionConfig>();

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQUpdateClientTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Subscription/Standalone/PQUpdateClientTests.cs
@@ -9,12 +9,12 @@ using FortitudeIO.Transports.Network.Construction;
 using FortitudeIO.Transports.Network.Controls;
 using FortitudeIO.Transports.Network.State;
 using FortitudeMarketsCore.Pricing.PQ.Serdes.Deserialization;
-using FortitudeMarketsCore.Pricing.PQ.Subscription;
+using FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 using Moq;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription;
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.Subscription.Standalone;
 
 [TestClass]
 public class PQUpdateClientTests

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/QuoteExtensionMethodsTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/QuoteExtensionMethodsTests.cs
@@ -30,7 +30,7 @@ public class QuoteExtensionMethodsTests
     private readonly DateTime originalQuoteExchangeTime = new(2015, 11, 17, 22, 07, 23);
 
     private readonly SourceTickerQuoteInfo originalSourceTickerQuoteInfo = new(1,
-        OriginalQuoteExchangeName, 1, OriginalQuoteTickerName, 20, 0.0001m, 1m, 1000000m, 1m);
+        OriginalQuoteExchangeName, 1, OriginalQuoteTickerName, QuoteLevel.Level3, 20, 0.0001m, 1m, 1000000m, 1m);
 
     private ILevel3Quote originalQuote = null!;
 
@@ -80,7 +80,7 @@ public class QuoteExtensionMethodsTests
         var q2 = originalQuote.Clone();
         var newExchangerName = "DifferentExchangeName";
         var newSourceTickerQuoteInfo = new SourceTickerQuoteInfo(1, newExchangerName, 1,
-            OriginalQuoteTickerName, 20, 0.0001m, 1m, 1000000m, 1m);
+            OriginalQuoteTickerName, QuoteLevel.Level3, 20, 0.0001m, 1m, 1000000m, 1m);
         NonPublicInvocator.SetAutoPropertyInstanceField(q2,
             (Level3PriceQuote pq) => pq.SourceTickerQuoteInfo, newSourceTickerQuoteInfo);
         var differences = originalQuote.DiffQuotes(q2);
@@ -102,7 +102,7 @@ public class QuoteExtensionMethodsTests
         var q2 = originalQuote.Clone();
         var newTickerName = "DifferentTicker";
         var newSourceTickerQuoteInfo = new SourceTickerQuoteInfo(1, OriginalQuoteExchangeName, 1,
-            newTickerName, 20, 0.0001m, 1m, 1000000m, 1m);
+            newTickerName, QuoteLevel.Level3, 20, 0.0001m, 1m, 1000000m, 1m);
         NonPublicInvocator.SetAutoPropertyInstanceField(q2, (Level3PriceQuote pq) => pq.SourceTickerQuoteInfo,
             newSourceTickerQuoteInfo);
         var differences = originalQuote.DiffQuotes(q2);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LastTraded/EntrySelector/LastTradeEntryFlagsSelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LastTraded/EntrySelector/LastTradeEntryFlagsSelectorTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.Quotes.LastTraded.EntrySelector;
 
 #endregion
@@ -21,7 +22,7 @@ public class LastTradeEntryFlagsSelectorTests
         layerSelector = new DummyLastTradeEntryFlagsSelector();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
     }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LastTraded/EntrySelector/RecentlyTradedLastTradeEntrySelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LastTraded/EntrySelector/RecentlyTradedLastTradeEntrySelectorTests.cs
@@ -2,6 +2,7 @@
 
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DictionaryCompression;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.LastTraded;
@@ -57,7 +58,7 @@ public class RecentlyTradedLastTradeEntrySelectorTests
         };
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
     }
 
     [TestMethod]

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/LayerSelector/LayerFlagsSelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/LayerSelector/LayerFlagsSelectorTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.Quotes.LayeredBook.LayerSelector;
 
 #endregion
@@ -21,7 +22,7 @@ public class LayerFlagsSelectorTests
         layerSelector = new DummyLayerFlagsSelectorTests();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
     }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/LayerSelector/OrderBookLayerFactorySelectorTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/LayerSelector/OrderBookLayerFactorySelectorTests.cs
@@ -3,6 +3,7 @@
 using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.LastTraded;
 using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DeltaUpdates;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.DictionaryCompression;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.LayeredBook;
@@ -87,7 +88,7 @@ public class OrderBookLayerFactorySelectorTests
         };
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
     }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/OrderBookTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/LayeredBook/OrderBookTests.cs
@@ -97,7 +97,7 @@ public class OrderBookTests
             simpleFullyPopulatedOrderBook, sourceFullyPopulatedOrderBook, sourceQtRefFullyPopulatedOrderBook
             , valueDateFullyPopulatedOrderBook, traderFullyPopulatedOrderBook, allFieldsFullyPopulatedOrderBook
         };
-        publicationPrecisionSettings = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", 20,
+        publicationPrecisionSettings = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20,
             0.00001m, 30000m, 50000000m, 1000m, 1, LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven |
                                                                                          LastTradedFlags.TraderName |
                                                                                          LastTradedFlags.LastTradedVolume |
@@ -108,28 +108,28 @@ public class OrderBookTests
     public void FromSourceTickerQuoteInfo_New_InitializesOrderBookWithExpectedLayerTypes()
     {
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume;
-        var orderBook = new OrderBook(publicationPrecisionSettings);
+        var orderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(PriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.SourceName | LayerFlags.Executable;
-        orderBook = new OrderBook(publicationPrecisionSettings);
+        orderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(SourcePriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.SourceName | LayerFlags.Executable |
                                                   LayerFlags.SourceQuoteReference;
-        orderBook = new OrderBook(publicationPrecisionSettings);
+        orderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(SourceQuoteRefPriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.ValueDate;
-        orderBook = new OrderBook(publicationPrecisionSettings);
+        orderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(ValueDatePriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume |
                                                   LayerFlags.TraderName | LayerFlags.TraderCount |
                                                   LayerFlags.TraderSize;
-        orderBook = new OrderBook(publicationPrecisionSettings);
+        orderBook = new OrderBook(BookSide.BidBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(TraderPriceVolumeLayer));
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price.AllFlags();
-        orderBook = new OrderBook(publicationPrecisionSettings);
+        orderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         AssertBookHasLayersOfType(orderBook, typeof(SourceQuoteRefTraderValueDatePriceVolumeLayer));
     }
 
@@ -230,7 +230,7 @@ public class OrderBookTests
         }
 
         publicationPrecisionSettings.LayerFlags = LayerFlags.Price | LayerFlags.Volume;
-        var emptyOrderBook = new OrderBook(publicationPrecisionSettings);
+        var emptyOrderBook = new OrderBook(BookSide.AskBook, publicationPrecisionSettings);
         Assert.AreEqual(0, emptyOrderBook.Count);
         var clonedEmptyOrderBook = new OrderBook(emptyOrderBook);
         Assert.AreEqual(0, clonedEmptyOrderBook.Count);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level0PriceQuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level0PriceQuoteTests.cs
@@ -29,7 +29,7 @@ public class Level0PriceQuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level1PriceQuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level1PriceQuoteTests.cs
@@ -29,7 +29,7 @@ public class Level1PriceQuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                                                   | LastTradedFlags.LastTradedVolume |

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level2PriceQuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level2PriceQuoteTests.cs
@@ -51,33 +51,33 @@ public class Level2PriceQuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         simpleSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                                   LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         sourceNameSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceName, LastTradedFlags.PaidOrGiven |
                                                                           LastTradedFlags.TraderName |
                                                                           LastTradedFlags.LastTradedVolume |
                                                                           LastTradedFlags.LastTradedTime);
         sourceQuoteRefSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceQuoteReference, LastTradedFlags.PaidOrGiven |
                                                                                     LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume |
                                                                                     LastTradedFlags.LastTradedTime);
         traderDetailsSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize |
             LayerFlags.TraderCount, LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                     LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         valueDateSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.ValueDate, LastTradedFlags.PaidOrGiven |
                                                                          LastTradedFlags.TraderName |
                                                                          LastTradedFlags.LastTradedVolume |
                                                                          LastTradedFlags.LastTradedTime);
         everyLayerSourceTickerQuoteInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume.AllFlags(), LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName |
                                           LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         simpleEmptyLevel2Quote = new Level2PriceQuote(simpleSourceTickerQuoteInfo);
@@ -137,8 +137,8 @@ public class Level2PriceQuoteTests
             Assert.AreEqual(0m, emptyL2Quote.AskPriceTop);
             Assert.AreEqual(false, emptyL2Quote.Executable);
             Assert.IsNull(emptyL2Quote.PeriodSummary);
-            Assert.AreEqual(new OrderBook(emptyL2Quote.SourceTickerQuoteInfo!), emptyL2Quote.BidBook);
-            Assert.AreEqual(new OrderBook(emptyL2Quote.SourceTickerQuoteInfo!), emptyL2Quote.AskBook);
+            Assert.AreEqual(new OrderBook(BookSide.BidBook, emptyL2Quote.SourceTickerQuoteInfo!), emptyL2Quote.BidBook);
+            Assert.AreEqual(new OrderBook(BookSide.AskBook, emptyL2Quote.SourceTickerQuoteInfo!), emptyL2Quote.AskBook);
             Assert.IsFalse(emptyL2Quote.IsBidBookChanged);
             Assert.IsFalse(emptyL2Quote.IsAskBookChanged);
         }
@@ -157,11 +157,11 @@ public class Level2PriceQuoteTests
         var expectedSourceAskTime = new DateTime(2018, 02, 04, 23, 56, 9);
         var expectedAskPriceTop = 3.45678m;
         var expectedPeriodSummary = new PeriodSummary();
-        var expectedBidBook = new OrderBook(simpleSourceTickerQuoteInfo)
+        var expectedBidBook = new OrderBook(BookSide.BidBook, simpleSourceTickerQuoteInfo)
         {
             [0] = new PriceVolumeLayer(expectedBidPriceTop, 1_000_000)
         };
-        var expectedAskBook = new OrderBook(simpleSourceTickerQuoteInfo)
+        var expectedAskBook = new OrderBook(BookSide.AskBook, simpleSourceTickerQuoteInfo)
         {
             [0] = new PriceVolumeLayer(expectedAskPriceTop, 1_000_000)
         };

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level3PriceQuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/Level3PriceQuoteTests.cs
@@ -46,23 +46,23 @@ public class Level3PriceQuoteTests
         quoteSequencedTestDataBuilder = new QuoteSequencedTestDataBuilder();
 
         noRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MaxValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.None);
         simpleRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue, "TestSource", ushort.MinValue,
-            "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice);
         paidGivenVolumeRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue,
-            "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice | LastTradedFlags.PaidOrGiven |
             LastTradedFlags.LastTradedVolume);
         traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo = new SourceTickerQuoteInfo(ushort.MaxValue,
-            "TestSource", ushort.MaxValue, "TestTicker", 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+            "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
             LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
             | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
             LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice | LastTradedFlags.TraderName);
@@ -119,8 +119,8 @@ public class Level3PriceQuoteTests
             Assert.AreEqual(0m, emptyL3Quote.AskPriceTop);
             Assert.AreEqual(false, emptyL3Quote.Executable);
             Assert.IsNull(emptyL3Quote.PeriodSummary);
-            Assert.AreEqual(new OrderBook(emptyL3Quote.SourceTickerQuoteInfo!), emptyL3Quote.BidBook);
-            Assert.AreEqual(new OrderBook(emptyL3Quote.SourceTickerQuoteInfo!), emptyL3Quote.AskBook);
+            Assert.AreEqual(new OrderBook(BookSide.BidBook, emptyL3Quote.SourceTickerQuoteInfo!), emptyL3Quote.BidBook);
+            Assert.AreEqual(new OrderBook(BookSide.AskBook, emptyL3Quote.SourceTickerQuoteInfo!), emptyL3Quote.AskBook);
             Assert.IsFalse(emptyL3Quote.IsBidBookChanged);
             Assert.IsFalse(emptyL3Quote.IsAskBookChanged);
             Assert.IsTrue(emptyL3Quote.RecentlyTraded == null ||
@@ -144,11 +144,11 @@ public class Level3PriceQuoteTests
         var expectedSourceAskTime = new DateTime(2018, 02, 04, 23, 56, 9);
         var expectedAskPriceTop = 3.45678m;
         var expectedPeriodSummary = new PeriodSummary();
-        var expectedBidBook = new OrderBook(simpleRecentlyTradedSrcTkrQtInfo)
+        var expectedBidBook = new OrderBook(BookSide.BidBook, simpleRecentlyTradedSrcTkrQtInfo)
         {
             [0] = new PriceVolumeLayer(expectedBidPriceTop, 1_000_000)
         };
-        var expectedAskBook = new OrderBook(simpleRecentlyTradedSrcTkrQtInfo)
+        var expectedAskBook = new OrderBook(BookSide.AskBook, simpleRecentlyTradedSrcTkrQtInfo)
         {
             [0] = new PriceVolumeLayer(expectedAskPriceTop, 1_000_000)
         };
@@ -204,11 +204,11 @@ public class Level3PriceQuoteTests
         var expectedSourceAskTime = new DateTime(2018, 02, 04, 23, 56, 9);
         var expectedAskPriceTop = 3.45678m;
         var expectedPeriodSummary = new PeriodSummary();
-        var expectedBidBook = new OrderBook(simpleRecentlyTradedSrcTkrQtInfo)
+        var expectedBidBook = new OrderBook(BookSide.BidBook, simpleRecentlyTradedSrcTkrQtInfo)
         {
             [0] = new PriceVolumeLayer(expectedBidPriceTop, 1_000_000)
         };
-        var expectedAskBook = new OrderBook(simpleRecentlyTradedSrcTkrQtInfo)
+        var expectedAskBook = new OrderBook(BookSide.AskBook, simpleRecentlyTradedSrcTkrQtInfo)
         {
             [0] = new PriceVolumeLayer(expectedAskPriceTop, 1_000_000)
         };

--- a/src/FortitudeTests/TestHelpers/TestMetrics.cs
+++ b/src/FortitudeTests/TestHelpers/TestMetrics.cs
@@ -19,7 +19,7 @@ public class TestMetrics
 {
     private const int MaxAllowedUntestedClassesInCommon = 144;
     private const int MaxAllowedUntestedClassesInFortitudeIO = 116;
-    private const int MaxAllowedUntestedClassesInFortitudeMarketsApi = 19;
+    private const int MaxAllowedUntestedClassesInFortitudeMarketsApi = 25;
     private const int MaxAllowedUntestedClassesInFortitudeMarketsCore = 125;
     private const int MaxAllowedUntestedClassesInFortitudeBusRules = 91;
     private IDictionary<string, List<Type>> fortitudeBusRulesAssemblyClasses = null!;


### PR DESCRIPTION
SourceTickerQuoteInfo now distributes PublishedQuoteLevel for clients to select most inclusive deserializer.