### PR TITLE
TimeSeriesFile uses reader for flexible result processing, 

### DIFF
--- a/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
@@ -3,7 +3,6 @@
 using System.Runtime.InteropServices;
 using FortitudeCommon.OSWrapper.Memory;
 using FortitudeCommon.Serdes.Binary;
-using FortitudeIO.Protocols;
 using FortitudeIO.Protocols.Serdes.Binary;
 using FortitudeIO.TimeSeries.FileSystem.File.Reading;
 
@@ -65,6 +64,7 @@ public interface IBucket : IDisposable
     Type ExpectedEntryType { get; }
     void RefreshViews(ShiftableMemoryMappedFileView? usingMappedFileView = null);
     bool Intersects(DateTime? fromTime = null, DateTime? toTime = null);
+    bool BucketIntersects(PeriodRange? period = null);
     StorageAttemptResult CheckTimeSupported(DateTime storageDateTime);
     void CloseFileView();
     IBucket OpenBucket(ShiftableMemoryMappedFileView? alternativeHeaderAndDataFileView = null, bool asWritable = false);
@@ -72,15 +72,7 @@ public interface IBucket : IDisposable
 
 public interface IBucket<TEntry> : IBucket where TEntry : ITimeSeriesEntry<TEntry>
 {
-    void Entries(IReaderContext<TEntry> readerContext);
-
-    IEnumerable<TEntry> AllBucketEntriesFrom(long? fromFileCursorOffset = null);
-    IEnumerable<TEntry> EntriesBetween(DateTime? fromTime = null, DateTime? toTime = null);
-
-    IEnumerable<TM> EntriesBetween<TM>(IMessageDeserializer<TM> usingMessageDeserializer, DateTime? fromTime = null, DateTime? toTime = null)
-        where TM : class, IVersionedMessage;
-
-    int CopyTo(List<TEntry> destination, DateTime? fromDateTime = null, DateTime? toDateTime = null);
+    IEnumerable<TEntry> ReadEntries(IReaderContext<TEntry> readerContext, long? fromFileCursorOffset = null);
 }
 
 public interface IMutableBucket : IBucket

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/BucketIndexInfo.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/BucketIndexInfo.cs
@@ -1,6 +1,7 @@
 ﻿#region
 
 using System.Runtime.InteropServices;
+using FortitudeIO.TimeSeries.FileSystem.File.Reading;
 using static FortitudeIO.TimeSeries.FileSystem.File.Buckets.BucketHeader;
 
 #endregion
@@ -60,4 +61,13 @@ public static class BucketIndexExtensions
     public static bool Intersects(this BucketIndexInfo bucketIndexInfo, DateTime? fromTime = null, DateTime? toTime = null) =>
         (bucketIndexInfo.BucketStartTime < toTime || (toTime == null && fromTime != null))
         && (bucketIndexInfo.BucketPeriod.PeriodEnd(bucketIndexInfo.BucketStartTime) > fromTime || (fromTime == null && toTime != null));
+
+    public static bool Intersects(this BucketIndexInfo bucketIndexInfo, PeriodRange? periodRange)
+    {
+        if (periodRange == null) return true;
+        var range = periodRange.Value;
+        return (bucketIndexInfo.BucketStartTime < range.ToTime || (range.ToTime == null && range.FromTime != null))
+               && (bucketIndexInfo.BucketPeriod.PeriodEnd(bucketIndexInfo.BucketStartTime) > range.FromTime
+                   || (range.FromTime == null && range.ToTime != null));
+    }
 }


### PR DESCRIPTION
early cancellation, limited results, limited simultaneous results, blocking queue multiple entry publishing options.