### PR TITLE
TimeSeriesFiles load derived TimeSeriesFile Type when opening existing file.

### DIFF
--- a/src/Fortitude.sln.DotSettings
+++ b/src/Fortitude.sln.DotSettings
@@ -32,6 +32,7 @@
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=C829790F78CAEB48B12D5931110E1D0A/Shortcut/@EntryValue">slogger</s:String>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=C829790F78CAEB48B12D5931110E1D0A/ShortenQualifiedReferences/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=C829790F78CAEB48B12D5931110E1D0A/Text/@EntryValue">private static readonly IFLogger Logger = FLoggerFactory.Instance.GetLogger(typeof($ContainingType$));</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Algo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Amender/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Attrbs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Chronometry/@EntryIndexedValue">True</s:Boolean>

--- a/src/FortitudeCommon/Types/ReflectionHelper.cs
+++ b/src/FortitudeCommon/Types/ReflectionHelper.cs
@@ -27,12 +27,31 @@ public static class ReflectionHelper
             Expression.New(constructorInfo, ctorParam), ctorParam).Compile();
     }
 
+    public static Func<TParam, TClassBaseType> CtorDerivedBinder<TParam, TClassBaseType>(Type classDerivedType)
+    {
+        var ctorParam = Expression.Parameter(typeof(TParam), "Param");
+        var constructorInfo
+            = classDerivedType.GetConstructor(new[] { typeof(TParam) })!;
+        return Expression.Lambda<Func<TParam, TClassBaseType>>(
+            Expression.New(constructorInfo, ctorParam), ctorParam).Compile();
+    }
+
     public static Func<TParam1, TParam2, TClass> CtorBinder<TParam1, TParam2, TClass>()
     {
         var ctorParam1 = Expression.Parameter(typeof(TParam1), "Param1");
         var ctorParam2 = Expression.Parameter(typeof(TParam2), "Param2");
         var constructorInfo = typeof(TClass).GetConstructor(new[] { typeof(TParam1), typeof(TParam2) })!;
         return Expression.Lambda<Func<TParam1, TParam2, TClass>>(
+            Expression.New(constructorInfo, ctorParam1, ctorParam2), ctorParam1
+            , ctorParam2).Compile();
+    }
+
+    public static Func<TParam1, TParam2, TClassBaseType> CtorDerivedBinder<TParam1, TParam2, TClassBaseType>(Type classDerivedType)
+    {
+        var ctorParam1 = Expression.Parameter(typeof(TParam1), "Param1");
+        var ctorParam2 = Expression.Parameter(typeof(TParam2), "Param2");
+        var constructorInfo = classDerivedType.GetConstructor(new[] { typeof(TParam1), typeof(TParam2) })!;
+        return Expression.Lambda<Func<TParam1, TParam2, TClassBaseType>>(
             Expression.New(constructorInfo, ctorParam1, ctorParam2), ctorParam1
             , ctorParam2).Compile();
     }

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/CreateFileParameters.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/CreateFileParameters.cs
@@ -1,0 +1,46 @@
+﻿namespace FortitudeIO.TimeSeries.FileSystem.File;
+
+public interface IDirectoryFileNameResolver
+{
+    DirectoryInfo RootDirPath { get; }
+    FileInfo FilePath(CreateFileParameters createFileParameters);
+    string FileName(CreateFileParameters createFileParameters);
+}
+
+public struct CreateFileParameters
+{
+    public CreateFileParameters(IDirectoryFileNameResolver fileNameResolver, string instrumentName, string sourceName,
+        TimeSeriesPeriod filePeriod, DateTime fileStartPeriod, TimeSeriesEntryType timeSeriesEntryType, uint internalIndexSize = 0,
+        FileFlags initialFileFlags = FileFlags.None, int initialFileSizePages = 2, ushort maxStringSizeBytes = byte.MaxValue,
+        string? category = null, ushort maxTypeStringSizeBytes = 512)
+    {
+        FileNameResolver = fileNameResolver;
+        InstrumentName = instrumentName;
+        SourceName = sourceName;
+        FilePeriod = filePeriod;
+        FileStartPeriod = fileStartPeriod;
+        TimeSeriesEntryType = timeSeriesEntryType;
+        InternalIndexSize = internalIndexSize;
+        InitialFileFlags = initialFileFlags;
+        InitialFileSizePages = initialFileSizePages;
+        MaxStringSizeBytes = maxStringSizeBytes;
+        Category = category;
+        MaxTypeStringSizeBytes = maxTypeStringSizeBytes;
+    }
+
+    public IDirectoryFileNameResolver FileNameResolver { get; set; }
+    public string InstrumentName { get; set; }
+    public string? Category { get; set; }
+    public string SourceName { get; set; }
+    public string? OriginSourceText { get; set; }
+    public string? ExternalIndexFileRelativePath { get; set; }
+    public string? AnnotationFileRelativePath { get; set; }
+    public TimeSeriesEntryType TimeSeriesEntryType { get; set; }
+    public TimeSeriesPeriod FilePeriod { get; set; }
+    public DateTime FileStartPeriod { get; set; }
+    public uint InternalIndexSize { get; set; }
+    public FileFlags InitialFileFlags { get; set; }
+    public int InitialFileSizePages { get; set; }
+    public ushort MaxStringSizeBytes { get; set; }
+    public ushort MaxTypeStringSizeBytes { get; set; }
+}

--- a/src/FortitudeIO/TimeSeries/TimeSeriesEntryType.cs
+++ b/src/FortitudeIO/TimeSeries/TimeSeriesEntryType.cs
@@ -1,0 +1,12 @@
+﻿namespace FortitudeIO.TimeSeries;
+
+public enum TimeSeriesEntryType : ushort
+{
+    Custom
+    , VenuePrice
+    , TickerPrice
+    , TickerPeriodSummary
+    , Indicator
+    , AlgoState
+    , AlgoSignal
+}

--- a/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TestDirectoryFileNameResolver.cs
+++ b/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TestDirectoryFileNameResolver.cs
@@ -1,0 +1,15 @@
+﻿#region
+
+using FortitudeIO.TimeSeries.FileSystem.File;
+
+#endregion
+
+namespace FortitudeTests.FortitudeIO.TimeSeries.FileSystem.File;
+
+public class TestDirectoryFileNameResolver : IDirectoryFileNameResolver
+{
+    public FileInfo TestTimeSeriesFile { get; set; }
+    public DirectoryInfo RootDirPath { get; set; }
+    public FileInfo FilePath(CreateFileParameters createFileParameters) => TestTimeSeriesFile;
+    public string FileName(CreateFileParameters createFileParameters) => TestTimeSeriesFile.Name;
+}


### PR DESCRIPTION
  Allows access to SubHeader and Parameters used for MessageDeserializer and verification of entry type being appended matching required type.