### PR TITLE
Since map file page sizes can vary between systems change requesting view to be in absolute bytes 

### DIFF
--- a/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
@@ -69,7 +69,7 @@ public interface IBucket : IDisposable
     bool                 Intersects(DateTime? fromTime = null, DateTime? toTime = null);
     bool                 BucketIntersects(PeriodRange? period = null);
     StorageAttemptResult CheckTimeSupported(DateTime storageDateTime);
-    void                 CloseFileView();
+    void                 CloseBucketFileViews();
     IBucket              OpenBucket(ShiftableMemoryMappedFileView? alternativeHeaderAndDataFileView = null, bool asWritable = false);
     void                 VisitChildrenCacheAndClose();
 }

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/CreateFileParameters.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/CreateFileParameters.cs
@@ -1,46 +1,49 @@
-﻿namespace FortitudeIO.TimeSeries.FileSystem.File;
+﻿// Licensed under the MIT license.
+// Copyright Alexis Sawenko 2024 all rights reserved
+
+namespace FortitudeIO.TimeSeries.FileSystem.File;
 
 public interface IDirectoryFileNameResolver
 {
     DirectoryInfo RootDirPath { get; }
-    FileInfo FilePath(CreateFileParameters createFileParameters);
-    string FileName(CreateFileParameters createFileParameters);
+    FileInfo      FilePath(CreateFileParameters createFileParameters);
+    string        FileName(CreateFileParameters createFileParameters);
 }
 
 public struct CreateFileParameters
 {
     public CreateFileParameters(IDirectoryFileNameResolver fileNameResolver, string instrumentName, string sourceName,
         TimeSeriesPeriod filePeriod, DateTime fileStartPeriod, TimeSeriesEntryType timeSeriesEntryType, uint internalIndexSize = 0,
-        FileFlags initialFileFlags = FileFlags.None, int initialFileSizePages = 2, ushort maxStringSizeBytes = byte.MaxValue,
+        FileFlags initialFileFlags = FileFlags.None, int initialFileSize = ushort.MaxValue * 2, ushort maxStringSizeBytes = byte.MaxValue,
         string? category = null, ushort maxTypeStringSizeBytes = 512)
     {
-        FileNameResolver = fileNameResolver;
-        InstrumentName = instrumentName;
-        SourceName = sourceName;
-        FilePeriod = filePeriod;
-        FileStartPeriod = fileStartPeriod;
-        TimeSeriesEntryType = timeSeriesEntryType;
-        InternalIndexSize = internalIndexSize;
-        InitialFileFlags = initialFileFlags;
-        InitialFileSizePages = initialFileSizePages;
-        MaxStringSizeBytes = maxStringSizeBytes;
-        Category = category;
+        FileNameResolver       = fileNameResolver;
+        InstrumentName         = instrumentName;
+        SourceName             = sourceName;
+        FilePeriod             = filePeriod;
+        FileStartPeriod        = fileStartPeriod;
+        TimeSeriesEntryType    = timeSeriesEntryType;
+        InternalIndexSize      = internalIndexSize;
+        InitialFileFlags       = initialFileFlags;
+        InitialFileSize        = initialFileSize;
+        MaxStringSizeBytes     = maxStringSizeBytes;
+        Category               = category;
         MaxTypeStringSizeBytes = maxTypeStringSizeBytes;
     }
 
-    public IDirectoryFileNameResolver FileNameResolver { get; set; }
-    public string InstrumentName { get; set; }
-    public string? Category { get; set; }
-    public string SourceName { get; set; }
-    public string? OriginSourceText { get; set; }
-    public string? ExternalIndexFileRelativePath { get; set; }
-    public string? AnnotationFileRelativePath { get; set; }
-    public TimeSeriesEntryType TimeSeriesEntryType { get; set; }
-    public TimeSeriesPeriod FilePeriod { get; set; }
-    public DateTime FileStartPeriod { get; set; }
-    public uint InternalIndexSize { get; set; }
-    public FileFlags InitialFileFlags { get; set; }
-    public int InitialFileSizePages { get; set; }
-    public ushort MaxStringSizeBytes { get; set; }
-    public ushort MaxTypeStringSizeBytes { get; set; }
+    public IDirectoryFileNameResolver FileNameResolver              { get; set; }
+    public string                     InstrumentName                { get; set; }
+    public string?                    Category                      { get; set; }
+    public string                     SourceName                    { get; set; }
+    public string?                    OriginSourceText              { get; set; }
+    public string?                    ExternalIndexFileRelativePath { get; set; }
+    public string?                    AnnotationFileRelativePath    { get; set; }
+    public TimeSeriesEntryType        TimeSeriesEntryType           { get; set; }
+    public TimeSeriesPeriod           FilePeriod                    { get; set; }
+    public DateTime                   FileStartPeriod               { get; set; }
+    public uint                       InternalIndexSize             { get; set; }
+    public FileFlags                  InitialFileFlags              { get; set; }
+    public int                        InitialFileSize               { get; set; }
+    public ushort                     MaxStringSizeBytes            { get; set; }
+    public ushort                     MaxTypeStringSizeBytes        { get; set; }
 }

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFile.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFile.cs
@@ -84,7 +84,7 @@ public unsafe class TimeSeriesFile<TBucket, TEntry> : ITimeSeriesFile<TBucket, T
     public TimeSeriesFile(CreateFileParameters createParameters)
     {
         FileName                   = createParameters.FileNameResolver.FilePath(createParameters).FullName;
-        TimeSeriesMemoryMappedFile = new PagedMemoryMappedFile(FileName, createParameters.InitialFileSizePages);
+        TimeSeriesMemoryMappedFile = new PagedMemoryMappedFile(FileName, createParameters.InitialFileSize);
         var headerFileView = TimeSeriesMemoryMappedFile.CreateShiftableMemoryMappedFileView("header");
         var ptr            = headerFileView.StartAddress;
         FileVersion = StreamByteOps.ToUShort(ref ptr);
@@ -182,7 +182,7 @@ public unsafe class TimeSeriesFile<TBucket, TEntry> : ITimeSeriesFile<TBucket, T
         if (existingOpen) return null;
         IncrementSessionCount();
         writerSession?.ReopenSession(FileFlags.WriterOpened);
-        writerSession ??= new TimeSeriesFileSession<TBucket, TEntry>(this, true);
+        writerSession ??= new TimeSeriesFileSession<TBucket, TEntry>(this, true, ushort.MaxValue * 4);
         return writerSession;
     }
 

--- a/src/FortitudeTests/FortitudeCommon/DataStructures/Memory/UnmanagedMemory/MemoryMappedFiles/PagedMemoryMappedFileTests.cs
+++ b/src/FortitudeTests/FortitudeCommon/DataStructures/Memory/UnmanagedMemory/MemoryMappedFiles/PagedMemoryMappedFileTests.cs
@@ -22,6 +22,8 @@ public class PagedMemoryMappedFileTests
     [TestInitialize]
     public void Setup()
     {
+        PagedMemoryMappedFile.LogFailedMappingAttempts = true;
+
         newMemoryMappedFilePath = Path.Combine(Environment.CurrentDirectory, GenerateUniqueFileNameOffDateTime());
         memoryMappedFile        = new FileInfo(newMemoryMappedFilePath);
         if (memoryMappedFile.Exists) memoryMappedFile.Delete();
@@ -84,7 +86,7 @@ public class PagedMemoryMappedFileTests
     {
         const int writeCursorOffset    = 16_234;
         const int writeAndFindValue    = 89_234_123;
-        using var onePageShiftableView = pagedMemoryMappedFile.CreateShiftableMemoryMappedFileView("onePageWrite", 1, 6, false);
+        using var onePageShiftableView = pagedMemoryMappedFile.CreateShiftableMemoryMappedFileView("onePageWrite", 0, ushort.MaxValue * 2, 6, false);
 
         var isAvailable = onePageShiftableView.IsUpperViewAvailableForContiguousReadWrite;
         Assert.IsTrue(isAvailable);
@@ -103,7 +105,7 @@ public class PagedMemoryMappedFileTests
         }
 
         onePageShiftableView.Dispose();
-        using var twoPageShiftableView = pagedMemoryMappedFile.CreateShiftableMemoryMappedFileView("twoPageRead", 2, 6);
+        using var twoPageShiftableView = pagedMemoryMappedFile.CreateShiftableMemoryMappedFileView("twoPageRead", 0, ushort.MaxValue * 4, 6);
         isAvailable = twoPageShiftableView.IsUpperViewAvailableForContiguousReadWrite;
         Assert.IsTrue(isAvailable);
         var assertedFoundValue = false;

--- a/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TestLevel1HourlyQuoteStructBucket.cs
+++ b/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TestLevel1HourlyQuoteStructBucket.cs
@@ -45,7 +45,7 @@ public unsafe class TestLevel1HourlyQuoteStructBucket : DataBucket<Level1QuoteSt
 
     protected Level1QuoteStruct GetEntryAt(long fileCursorOffset)
     {
-        var ptr = (Level1QuoteStruct*)BucketAppenderFileView!.FileCursorBufferPointer(fileCursorOffset);
+        var ptr = (Level1QuoteStruct*)BucketAppenderDataReaderFileView!.FileCursorBufferPointer(fileCursorOffset);
         return *ptr;
     }
 
@@ -58,7 +58,7 @@ public unsafe class TestLevel1HourlyQuoteStructBucket : DataBucket<Level1QuoteSt
         var checkWithinRange = CheckTimeSupported(entryStorageTime);
         if (checkWithinRange != StorageAttemptResult.PeriodRangeMatched) return checkWithinRange;
         var writeFileOffset = BucketDataStartFileOffset + (long)DataSizeBytes;
-        var ptr             = (Level1QuoteStruct*)BucketAppenderFileView!.FileCursorBufferPointer(writeFileOffset, shouldGrow: true);
+        var ptr             = (Level1QuoteStruct*)BucketAppenderDataReaderFileView!.FileCursorBufferPointer(writeFileOffset, shouldGrow: true);
         *ptr             =  entry;
         DataSizeBytes    += (ulong)sizeof(Level1QuoteStruct);
         DataEntriesCount += 1;

--- a/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFileTests.cs
@@ -1,6 +1,10 @@
-﻿#region
+﻿// Licensed under the MIT license.
+// Copyright Alexis Sawenko 2024 all rights reserved
+
+#region
 
 using FortitudeCommon.Chronometry;
+using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeCommon.Extensions;
 using FortitudeCommon.Monitoring.Logging;
 using FortitudeIO.TimeSeries;
@@ -16,21 +20,22 @@ namespace FortitudeTests.FortitudeIO.TimeSeries.FileSystem.File;
 [TestClass]
 public class TimeSeriesFileTests
 {
-    private static readonly IFLogger Logger = FLoggerFactory.Instance.GetLogger(typeof(TimeSeriesFileTests));
-    private static int newTestCount;
-    private Func<Level1QuoteStruct>? createNewEntryFactory;
-    private CreateFileParameters createTestCreateFileParameters;
+    private static readonly IFLogger                 Logger = FLoggerFactory.Instance.GetLogger(typeof(TimeSeriesFileTests));
+    private static          int                      newTestCount;
+    private                 Func<Level1QuoteStruct>? createNewEntryFactory;
+    private                 CreateFileParameters     createTestCreateFileParameters;
 
-    private TimeSeriesFile<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct> oneWeekFile = null!;
+    private TimeSeriesFile<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct>      oneWeekFile = null!;
     private IReaderFileSession<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct>? readerSession;
-    private TestDirectoryFileNameResolver testFileNameResolver = null!;
-    private string testTimeSeriesFilePath = null!;
-    private FileInfo timeSeriesFile = null!;
-    private IWriterFileSession<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct> writerSession = null!;
+    private TestDirectoryFileNameResolver                                            testFileNameResolver   = null!;
+    private string                                                                   testTimeSeriesFilePath = null!;
+    private FileInfo                                                                 timeSeriesFile         = null!;
+    private IWriterFileSession<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct>  writerSession          = null!;
 
     [TestInitialize]
     public void Setup()
     {
+        PagedMemoryMappedFile.LogFailedMappingAttempts = true;
         testTimeSeriesFilePath = Path.Combine(Environment.CurrentDirectory, GenerateUniqueFileNameOffDateTime());
         timeSeriesFile = new FileInfo(testTimeSeriesFilePath);
         createNewEntryFactory = () => new Level1QuoteStruct(DateTimeConstants.UnixEpoch, 0m, DateTimeConstants.UnixEpoch, 0m, 0m, false);
@@ -40,11 +45,11 @@ public class TimeSeriesFileTests
             TestTimeSeriesFile = timeSeriesFile
         };
         createTestCreateFileParameters = new CreateFileParameters(testFileNameResolver,
-            "TestInstrumentName", "TestSourceName",
-            TimeSeriesPeriod.OneWeek, DateTime.UtcNow.Date, TimeSeriesEntryType.Price, 7,
-            FileFlags.WriterOpened | FileFlags.HasInternalIndexInHeader, 6,
-            category: "TestInstrumentCategory");
-        oneWeekFile = new TimeSeriesFile<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct>(createTestCreateFileParameters);
+                                                                  "TestInstrumentName", "TestSourceName",
+                                                                  TimeSeriesPeriod.OneWeek, DateTime.UtcNow.Date, TimeSeriesEntryType.Price, 7,
+                                                                  FileFlags.WriterOpened | FileFlags.HasInternalIndexInHeader, 6,
+                                                                  category: "TestInstrumentCategory");
+        oneWeekFile   = new TimeSeriesFile<TestLevel1DailyQuoteStructBucket, Level1QuoteStruct>(createTestCreateFileParameters);
         writerSession = oneWeekFile.GetWriterSession()!;
     }
 
@@ -85,7 +90,7 @@ public class TimeSeriesFileTests
         readerSession = oneWeekFile.GetReaderSession();
         writerSession.Close();
         var allEntriesReader = readerSession.GetAllEntriesReader(createNewEntryFactory);
-        var storedItems = allEntriesReader.ResultEnumerable.ToList();
+        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -107,8 +112,8 @@ public class TimeSeriesFileTests
     public void CreateNewFile_SetLargeStringsWhichAreTruncated_CloseReopenSafelyReturnsTruncatedStrings()
     {
         var largeString = 999.CharIndexPosListedSizeString();
-        var truncated = largeString.Substring(0, 254); // byte.MaxValue -1 (largest storable value)  (-1 null terminator)
-        var header = oneWeekFile.Header;
+        var truncated   = largeString.Substring(0, 254); // byte.MaxValue -1 (largest storable value)  (-1 null terminator)
+        var header      = oneWeekFile.Header;
         header.AnnotationFileRelativePath = largeString;
         Assert.AreEqual(truncated, header.AnnotationFileRelativePath);
         header.ExternalIndexFileRelativePath = largeString;
@@ -150,7 +155,7 @@ public class TimeSeriesFileTests
     {
         Assert.AreEqual(TimeSeriesEntryType.Price, oneWeekFile.TimeSeriesEntryType);
         var singleQuoteMiddleOfWeek = GenerateRepeatableL1QuoteStructs(1, 1, 12, DayOfWeek.Wednesday);
-        var nextWeekQuote = singleQuoteMiddleOfWeek.First();
+        var nextWeekQuote           = singleQuoteMiddleOfWeek.First();
         nextWeekQuote.SourceTime = nextWeekQuote.SourceTime.AddDays(7);
         var result = writerSession.AppendEntry(nextWeekQuote);
         Assert.AreEqual(StorageAttemptResult.NextFilePeriod, result);
@@ -160,10 +165,10 @@ public class TimeSeriesFileTests
     public void CreateNewFile_AfterBucketClosesOnNextEntry_TryingToAddExistingEntryReturnsBucketClosedForAppend()
     {
         var wednesdayQuotes = GenerateRepeatableL1QuoteStructs(1, 1, 12, DayOfWeek.Wednesday);
-        var thursdayQuotes = GenerateRepeatableL1QuoteStructs(1, 1, 12, DayOfWeek.Thursday);
-        var wednesdayQuote = wednesdayQuotes.First();
-        var thursdayQuote = thursdayQuotes.First();
-        var result = writerSession.AppendEntry(wednesdayQuote);
+        var thursdayQuotes  = GenerateRepeatableL1QuoteStructs(1, 1, 12, DayOfWeek.Thursday);
+        var wednesdayQuote  = wednesdayQuotes.First();
+        var thursdayQuote   = thursdayQuotes.First();
+        var result          = writerSession.AppendEntry(wednesdayQuote);
         Assert.AreEqual(StorageAttemptResult.PeriodRangeMatched, result);
         result = writerSession.AppendEntry(thursdayQuote);
         Assert.AreEqual(StorageAttemptResult.PeriodRangeMatched, result);
@@ -173,11 +178,11 @@ public class TimeSeriesFileTests
 
     public IEnumerable<Level1QuoteStruct> GenerateForEachDayAndHourOfCurrentWeek(int start, int amount)
     {
-        var dateToGenerate = DateTime.UtcNow.Date;
+        var dateToGenerate   = DateTime.UtcNow.Date;
         var currentDayOfWeek = dateToGenerate.DayOfWeek;
-        var dayDiff = DayOfWeek.Sunday - currentDayOfWeek;
-        var startOfWeek = dateToGenerate.AddDays(dayDiff);
-        var currentDay = startOfWeek;
+        var dayDiff          = DayOfWeek.Sunday - currentDayOfWeek;
+        var startOfWeek      = dateToGenerate.AddDays(dayDiff);
+        var currentDay       = startOfWeek;
         for (var i = 0; i < 7; i++)
         {
             for (var j = 0; j < 24; j++)
@@ -189,17 +194,17 @@ public class TimeSeriesFileTests
 
     private IEnumerable<Level1QuoteStruct> GenerateRepeatableL1QuoteStructs(int start, int amount, int hour, DayOfWeek forDayOfWeek)
     {
-        var dateToGenerate = DateTime.UtcNow.Date;
+        var dateToGenerate   = DateTime.UtcNow.Date;
         var currentDayOfWeek = dateToGenerate.DayOfWeek;
-        var dayDiff = forDayOfWeek - currentDayOfWeek;
-        var generateDate = dateToGenerate.AddDays(dayDiff);
-        var hourToGenerate = TimeSpan.FromHours(hour);
+        var dayDiff          = forDayOfWeek - currentDayOfWeek;
+        var generateDate     = dateToGenerate.AddDays(dayDiff);
+        var hourToGenerate   = TimeSpan.FromHours(hour);
         var generateDateHour = generateDate.Add(hourToGenerate);
 
         for (var i = start; i < start + amount; i++)
             yield return new Level1QuoteStruct(generateDateHour + TimeSpan.FromSeconds(i), 1.2345m + i * 0.0001m,
-                generateDateHour + TimeSpan.FromSeconds(i) + TimeSpan.FromMilliseconds(i),
-                1.2345m - i * 0.0002m, 1.2345m + i * 0.0002m, true);
+                                               generateDateHour + TimeSpan.FromSeconds(i) + TimeSpan.FromMilliseconds(i),
+                                               1.2345m - i * 0.0002m, 1.2345m + i * 0.0002m, true);
     }
 
     private string GenerateUniqueFileNameOffDateTime()


### PR DESCRIPTION
to ensure this doesn't vary between systems.  Also added checks to ensure view can map expected file range and implemented in TimeSeriesFiles.