### PR TITLE
Added price and volume scaling from SourceTickerQuoteInfo

### DIFF
--- a/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfo.cs
+++ b/src/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfo.cs
@@ -60,8 +60,9 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
         Ticker = null!;
     }
 
-    public SourceTickerQuoteInfo(ushort sourceId, string source, ushort tickerId, string ticker, QuoteLevel publishedQuoteLevel,
-        MarketClassification marketClassification, byte maximumPublishedLayers = 20, decimal roundingPrecision = 0.0001m,
+    public SourceTickerQuoteInfo
+    (ushort sourceId, string source, ushort tickerId, string ticker, QuoteLevel publishedQuoteLevel,
+        MarketClassification marketClassification, byte maximumPublishedLayers = 20, decimal roundingPrecision = 0.00001m,
         decimal minSubmitSize = 0.01m, decimal maxSubmitSize = 1_000_000m, decimal incrementSize = 0.01m, ushort minimumQuoteLife = 100,
         LayerFlags layerFlags = LayerFlags.Price | LayerFlags.Volume,
         LastTradedFlags lastTradedFlags = LastTradedFlags.None)
@@ -178,7 +179,8 @@ public class SourceTickerQuoteInfo : ReusableObject<ISourceTickerQuoteInfo>, ISo
     IVersionedMessage IStoreState<IVersionedMessage>.CopyFrom(IVersionedMessage source, CopyMergeFlags copyMergeFlags) =>
         CopyFrom((ISourceTickerQuoteInfo)source, copyMergeFlags);
 
-    IReusableObject<IVersionedMessage> IStoreState<IReusableObject<IVersionedMessage>>.CopyFrom(IReusableObject<IVersionedMessage> source
+    IReusableObject<IVersionedMessage> IStoreState<IReusableObject<IVersionedMessage>>.CopyFrom
+    (IReusableObject<IVersionedMessage> source
       , CopyMergeFlags copyMergeFlags) =>
         CopyFrom((ISourceTickerQuoteInfo)source, copyMergeFlags);
 

--- a/src/FortitudeMarketsApi/Pricing/TimeSeries/FileSystem/File/PriceQuoteSubHeader.cs
+++ b/src/FortitudeMarketsApi/Pricing/TimeSeries/FileSystem/File/PriceQuoteSubHeader.cs
@@ -10,7 +10,7 @@ using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 
 namespace FortitudeMarketsApi.Pricing.TimeSeries.FileSystem.File;
 
-public interface IPriceQuoteFileHeader : IFileSubHeader
+public interface IPriceFileHeader : IFileSubHeader
 {
     ISourceTickerQuoteInfo SourceTickerQuoteInfo { get; }
 }

--- a/src/FortitudeMarketsApi/Pricing/TimeSeries/FileSystem/File/PriceQuoteTimeSeriesFile.cs
+++ b/src/FortitudeMarketsApi/Pricing/TimeSeries/FileSystem/File/PriceQuoteTimeSeriesFile.cs
@@ -11,5 +11,5 @@ namespace FortitudeMarketsApi.Pricing.TimeSeries.FileSystem.File;
 
 public interface IPriceQuoteTimeSeriesFile : ITimeSeriesFile
 {
-    IPriceQuoteFileHeader PriceQuoteFileHeader { get; }
+    IPriceFileHeader PriceFileHeader { get; }
 }

--- a/src/FortitudeMarketsCore/FortitudeMarketsCore.csproj
+++ b/src/FortitudeMarketsCore/FortitudeMarketsCore.csproj
@@ -24,7 +24,6 @@
     <Folder Include="Configuration\ClientServerConfig\PricingConfig\" />
     <Folder Include="Configuration\ClientServerConfig\TradingConfig\" />
     <Folder Include="Pricing\Quotes\SourceTickerInfo\" />
-    <Folder Include="Pricing\TimeSeries\FileSystem\File\Buckets\" />
   </ItemGroup>
 
 </Project>

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/DeltaUpdates/PQScaling.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/DeltaUpdates/PQScaling.cs
@@ -39,6 +39,21 @@ public static class PQScaling
 
     public static uint Scale(decimal value, byte flag) => (uint)(Math.Abs(value) * Factors[16 - (flag & FactorMask)]);
 
+    public static byte FindScaleFactor(decimal precisionExample)
+    {
+        if (precisionExample < 1m && precisionExample.Scale is > 0 and < 8) return (byte)(8 - precisionExample.Scale);
+        if (precisionExample is >= 1m and < 10m) return 8;
+        var currentScale = precisionExample;
+        var count        = 1;
+        while (currentScale > 10m)
+        {
+            count++;
+            currentScale /= 10;
+        }
+        if (count < 8) return (byte)(8 + count);
+        throw new Exception("Example precision value is greater than PQScaling support");
+    }
+
     public static uint AutoScale(decimal value, int maxNumberOfSignificantDigits, out byte flagSelected)
     {
         int afterDecimalPoint = BitConverter.GetBytes(decimal.GetBits(value)[3])[2];

--- a/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/PQSourceTickerQuoteInfo.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/SourceTickerInfo/PQSourceTickerQuoteInfo.cs
@@ -3,7 +3,6 @@
 
 #region
 
-using System.Diagnostics;
 using System.Globalization;
 using FortitudeCommon.DataStructures.Maps.IdMap;
 using FortitudeCommon.DataStructures.Memory;
@@ -92,6 +91,9 @@ public class PQSourceTickerQuoteInfo : ReusableObject<PQSourceTickerQuoteInfo>, 
         LayerFlags       = layerFlags;
         LastTradedFlags  = lastTradedFlags;
 
+        PriceScalingPrecision  = PQScaling.FindScaleFactor(RoundingPrecision);
+        VolumeScalingPrecision = PQScaling.FindScaleFactor(Math.Min(MinSubmitSize, IncrementSize));
+
         Category = PublishedQuoteLevel.ToString();
     }
 
@@ -116,6 +118,9 @@ public class PQSourceTickerQuoteInfo : ReusableObject<PQSourceTickerQuoteInfo>, 
 
         Category = PublishedQuoteLevel.ToString();
 
+        PriceScalingPrecision  = PQScaling.FindScaleFactor(RoundingPrecision);
+        VolumeScalingPrecision = PQScaling.FindScaleFactor(Math.Min(MinSubmitSize, IncrementSize));
+
         if (toClone is IPQSourceTickerQuoteInfo pubToClone)
         {
             IsIdUpdated     = pubToClone.IsIdUpdated;
@@ -137,8 +142,8 @@ public class PQSourceTickerQuoteInfo : ReusableObject<PQSourceTickerQuoteInfo>, 
         }
     }
 
-    public byte PriceScalingPrecision  { get; set; } = 1;
-    public byte VolumeScalingPrecision { get; }      = 6;
+    public byte PriceScalingPrecision  { get; } = 3;
+    public byte VolumeScalingPrecision { get; } = 6;
 
     public virtual bool HasUpdates
     {
@@ -525,7 +530,6 @@ public class PQSourceTickerQuoteInfo : ReusableObject<PQSourceTickerQuoteInfo>, 
         var allAreSame = sourceIdSame && tickerIdSame && sourceNameSame && tickerNameSame && quoteLevelSame && marketClassificationSame
                       && roundingPrecisionSame && minSubmitSizeSame && maxSubmitSizeSame && incrementSizeSame && minQuoteLifeSame
                       && layerFlagsSame && maxPublishLayersSame && lastTradedFlagsSame && updatesSame;
-        if (!allAreSame) Debugger.Break();
         return allAreSame;
     }
 

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PQAppendContext.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PQAppendContext.cs
@@ -6,9 +6,11 @@
 using FortitudeIO.TimeSeries;
 using FortitudeIO.TimeSeries.FileSystem.File.Buckets;
 using FortitudeIO.TimeSeries.FileSystem.File.Session;
+using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
 using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsApi.Pricing.TimeSeries;
 using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes;
+using FortitudeMarketsCore.Pricing.PQ.Messages.Quotes.SourceTickerInfo;
 using FortitudeMarketsCore.Pricing.PQ.Summaries;
 
 #endregion
@@ -40,5 +42,9 @@ public class PQPricePeriodSummaryAppendContext<TEntry, TBucket> : AppendContext<
     where TEntry : ITimeSeriesEntry<TEntry>, IPricePeriodSummary
     where TBucket : class, IBucketNavigation<TBucket>, IMutableBucket<TEntry>
 {
-    public IPQPriceStoragePeriodSummary SerializeEntry { get; } = new PQPriceStoragePeriodSummary();
+    public PQPricePeriodSummaryAppendContext
+        (ISourceTickerQuoteInfo sourceTickerQuoteInfo) =>
+        SerializeEntry = new PQPriceStoragePeriodSummary(new PQSourceTickerQuoteInfo(sourceTickerQuoteInfo));
+
+    public IPQPriceStoragePeriodSummary SerializeEntry { get; }
 }

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceFileSubHeader.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceFileSubHeader.cs
@@ -16,7 +16,7 @@ using FortitudeMarketsCore.Pricing.PQ.Serdes.Serialization;
 
 namespace FortitudeMarketsCore.Pricing.PQ.TimeSeries.FileSystem.File;
 
-public interface ISerializationPriceFileHeader : IPriceQuoteFileHeader
+public interface ISerializationPriceFileHeader : IPriceFileHeader
 {
     PQSerializationFlags SerializationFlags { get; set; }
 }

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceQuoteTimeSeriesFile.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceQuoteTimeSeriesFile.cs
@@ -25,7 +25,7 @@ public class PriceQuoteTimeSeriesFile<TFile, TBucket, TEntry> : TimeSeriesFile<T
         : base(pagedMemoryMappedFile, header)
     {
         Header.SubHeaderFactory = (view, offset, writable) => new PriceFileSubHeader(view, offset, writable);
-        PriceQuoteFileHeader    = (IPriceQuoteFileHeader)Header.SubHeader!;
+        PriceFileHeader         = (IPriceFileHeader)Header.SubHeader!;
     }
 
     public PriceQuoteTimeSeriesFile(PriceTimeSeriesFileParameters sourceTickerTimeSeriesFileParams)
@@ -33,14 +33,14 @@ public class PriceQuoteTimeSeriesFile<TFile, TBucket, TEntry> : TimeSeriesFile<T
     {
         Header.FileFlags        |= FileFlags.HasSubFileHeader | FileFlags.HasInternalIndexInHeader;
         Header.SubHeaderFactory =  (view, offset, writable) => new PriceFileSubHeader(sourceTickerTimeSeriesFileParams, view, offset, writable);
-        PriceQuoteFileHeader    =  (IPriceQuoteFileHeader)Header.SubHeader!;
+        PriceFileHeader         =  (IPriceFileHeader)Header.SubHeader!;
     }
 
     public override IBucketFactory<TBucket> RootBucketFactory
     {
-        get { return FileBucketFactory ??= new PriceBucketFactory<TBucket>(PriceQuoteFileHeader.SourceTickerQuoteInfo, true); }
+        get { return FileBucketFactory ??= new PriceBucketFactory<TBucket>(PriceFileHeader.SourceTickerQuoteInfo, true); }
         set => FileBucketFactory = value;
     }
 
-    public IPriceQuoteFileHeader PriceQuoteFileHeader { get; }
+    public IPriceFileHeader PriceFileHeader { get; }
 }

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryFiles.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryFiles.cs
@@ -7,8 +7,6 @@ using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeIO.TimeSeries;
 using FortitudeIO.TimeSeries.FileSystem.File;
 using FortitudeIO.TimeSeries.FileSystem.File.Header;
-using FortitudeIO.TimeSeries.FileSystem.File.Session;
-using FortitudeMarketsApi.Pricing.TimeSeries;
 using FortitudeMarketsCore.Pricing.PQ.TimeSeries.FileSystem.File.Buckets;
 
 #endregion
@@ -28,9 +26,6 @@ public class WeeklyDailyHourlyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(7)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, DailyToHourlyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, DailyToHourlyPriceSummarySubBuckets>();
-
     public static WeeklyDailyHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
 
@@ -46,9 +41,6 @@ public class WeeklyFourHourlyPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(42)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, FourHourlyPriceSummaryDataBucket> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, FourHourlyPriceSummaryDataBucket>();
 
     public static WeeklyFourHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
@@ -66,9 +58,6 @@ public class MonthlyFourHourlyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(186)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, FourHourlyPriceSummaryDataBucket> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, FourHourlyPriceSummaryDataBucket>();
-
     public static MonthlyFourHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
 
@@ -85,9 +74,6 @@ public class MonthlyDailyHourlyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(31)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, DailyToHourlyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, DailyToHourlyPriceSummarySubBuckets>();
-
     public static MonthlyDailyHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
 
@@ -103,9 +89,6 @@ public class MonthlyWeeklyFourHourlyPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(4)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, WeeklyToFourHourlyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, WeeklyToFourHourlyPriceSummarySubBuckets>();
 
     public static MonthlyWeeklyFourHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile
         (FileInfo file) =>
@@ -125,9 +108,6 @@ public class MonthlyWeeklyDailyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(4)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, WeeklyToDailyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, WeeklyToDailyPriceSummarySubBuckets>();
-
     public static MonthlyWeeklyDailyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
 
@@ -143,9 +123,6 @@ public class YearlyMonthlyFourHourlyPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(12)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, MonthlyToFourHourlyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, MonthlyToFourHourlyPriceSummarySubBuckets>();
 
     public static YearlyMonthlyFourHourlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile
         (FileInfo file) =>
@@ -165,9 +142,6 @@ public class YearlyWeeklyDailyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(53)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, WeeklyToDailyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, WeeklyToDailyPriceSummarySubBuckets>();
-
     public static YearlyWeeklyDailyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }
 
@@ -183,9 +157,6 @@ public class YearlyMonthlyWeeklyPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(12)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, MonthlyToWeeklyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, MonthlyToWeeklyPriceSummarySubBuckets>();
 
     public static YearlyMonthlyWeeklyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) =>
         OpenExistingTimeSeriesFile(file.FullName);
@@ -204,9 +175,6 @@ public class DecenniallyMonthlyWeeklyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(120)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, MonthlyToWeeklyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, MonthlyToWeeklyPriceSummarySubBuckets>();
-
     public static DecenniallyMonthlyWeeklyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) =>
         OpenExistingTimeSeriesFile(file.FullName);
 }
@@ -223,9 +191,6 @@ public class DecenniallyYearlyMonthlyPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(10)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, YearlyToMonthlyPriceSummarySubBuckets> CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, YearlyToMonthlyPriceSummarySubBuckets>();
 
     public static DecenniallyYearlyMonthlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) =>
         OpenExistingTimeSeriesFile(file.FullName);
@@ -244,10 +209,6 @@ public class UnlimitedDecenniallyYearlyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(10)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, DecenniallyToYearlyPriceSummarySubBuckets>
-        CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, DecenniallyToYearlyPriceSummarySubBuckets>();
-
     public static UnlimitedDecenniallyYearlyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) =>
         OpenExistingTimeSeriesFile(file.FullName);
 }
@@ -265,10 +226,6 @@ public class UnlimitedDecenniallyPriceSummaryTimeSeriesFile :
                                                .SetInternalIndexSize(1)
                                                .SetInitialFileSize(512 * 1024)) { }
 
-    public override ISessionAppendContext<IPricePeriodSummary, DecenniallyPriceSummaryDataBucket>
-        CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, DecenniallyPriceSummaryDataBucket>();
-
     public static UnlimitedDecenniallyPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) =>
         OpenExistingTimeSeriesFile(file.FullName);
 }
@@ -285,10 +242,6 @@ public class UnlimitedPriceSummaryTimeSeriesFile :
                                                .SetFileFlags(FileFlags.HasSubFileHeader)
                                                .SetInternalIndexSize(1)
                                                .SetInitialFileSize(512 * 1024)) { }
-
-    public override ISessionAppendContext<IPricePeriodSummary, UnlimitedPriceSummaryDataBucket>
-        CreateAppendContext() =>
-        new PQPricePeriodSummaryAppendContext<IPricePeriodSummary, UnlimitedPriceSummaryDataBucket>();
 
     public static UnlimitedPriceSummaryTimeSeriesFile OpenExistingTimeSeriesFile(FileInfo file) => OpenExistingTimeSeriesFile(file.FullName);
 }

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/PQOneWeekQuoteRepoFileFactory.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/PQOneWeekQuoteRepoFileFactory.cs
@@ -19,16 +19,14 @@ public class PQOneWeekQuoteRepoFileFactory<TEntry> : TimeSeriesRepositoryFileFac
 
 {
     protected override TimeSeriesFileParameters CreateTimeSeriesFileParameters
-    (FileInfo fileInfo, IInstrument instrument,
-        TimeSeriesPeriod filePeriod, DateTime filePeriodTime)
+        (FileInfo fileInfo, IInstrument instrument, TimeSeriesPeriod filePeriod, DateTime filePeriodTime)
     {
         var fileStart = filePeriod.ContainingPeriodBoundaryStart(filePeriodTime);
         return new TimeSeriesFileParameters(fileInfo, instrument, filePeriod, fileStart, 7, FileFlags.WriterOpened);
     }
 
     protected virtual PriceTimeSeriesFileParameters CreatePriceQuoteTimeSeriesFileParameters
-    (FileInfo fileInfo, IInstrument instrument,
-        TimeSeriesPeriod filePeriod, DateTime filePeriodTime)
+        (FileInfo fileInfo, IInstrument instrument, TimeSeriesPeriod filePeriod, DateTime filePeriodTime)
     {
         if (filePeriod != TimeSeriesPeriod.OneWeek) throw new Exception("Expected file period to be one week");
         var sourceTickerQuoteInfo = instrument as ISourceTickerQuoteInfo;
@@ -56,8 +54,7 @@ public class PQOneWeekQuoteRepoFileFactory<TEntry> : TimeSeriesRepositoryFileFac
     }
 
     public override ITimeSeriesEntryFile<TEntry> OpenOrCreate
-    (FileInfo fileInfo, IInstrument instrument, TimeSeriesPeriod filePeriod
-      , DateTime filePeriodTime)
+        (FileInfo fileInfo, IInstrument instrument, TimeSeriesPeriod filePeriod, DateTime filePeriodTime)
     {
         var priceQuoteFileParams = CreatePriceQuoteTimeSeriesFileParameters(fileInfo, instrument, filePeriod, filePeriodTime);
         return EntryType switch

--- a/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/DymwiTimeSeriesDirectoryRepositoryTests.cs
+++ b/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/DymwiTimeSeriesDirectoryRepositoryTests.cs
@@ -64,7 +64,7 @@ public class DymwiTimeSeriesDirectoryRepositoryTests
         level3SrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (19, "DymwiTest", 79, "RepoTest", Level3, FxMajor
-               , 5, layerFlags: LayerFlags.SourceQuoteReference, lastTradedFlags: LastTradedFlags.PaidOrGiven);
+               , 5, layerFlags: LayerFlags.SourceQuoteReference, lastTradedFlags: LastTradedFlags.PaidOrGiven, roundingPrecision: 0.000001m);
 
         var generateQuoteInfo = new GenerateQuoteInfo(level3SrcTkrQtInfo);
         generateQuoteInfo.MidPriceGenerator!.StartTime  = week1.Date;

--- a/src/FortitudeTests/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfoTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsApi/Configuration/ClientServerConfig/PricingConfig/SourceTickerQuoteInfoTests.cs
@@ -81,7 +81,7 @@ public class SourceTickerQuoteInfoTests
         Assert.AreEqual("MinimalSource", minimalSrcTkrQtInfo.Source);
         Assert.AreEqual("MinalTicker", minimalSrcTkrQtInfo.Ticker);
         Assert.AreEqual(20, minimalSrcTkrQtInfo.MaximumPublishedLayers);
-        Assert.AreEqual(0.0001m, minimalSrcTkrQtInfo.RoundingPrecision);
+        Assert.AreEqual(0.00001m, minimalSrcTkrQtInfo.RoundingPrecision);
         Assert.AreEqual(0.01m, minimalSrcTkrQtInfo.MinSubmitSize);
         Assert.AreEqual(1_000_000m, minimalSrcTkrQtInfo.MaxSubmitSize);
         Assert.AreEqual(0.01m, minimalSrcTkrQtInfo.IncrementSize);
@@ -201,7 +201,7 @@ public class SourceTickerQuoteInfoTests
         // ReSharper disable RedundantArgumentDefaultValue
         var matchingStqi = new SourceTickerQuoteInfo
             (1, "TestSource", 1, "TestTicker", QuoteLevel.Level2, Unknown,
-             20, 0.0001m, 0.01m,
+             20, 0.00001m, 0.01m,
              1_000_000, 0.01m, 100, LayerFlags.Price | LayerFlags.Volume, LastTradedFlags.None);
         Assert.AreEqual(commonStqi, matchingStqi);
         // ReSharper restore RedundantArgumentDefaultValue

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/LocalHostPQTestSetupCommon.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/LocalHostPQTestSetupCommon.cs
@@ -48,25 +48,27 @@ public class LocalHostPQTestSetupCommon
             new SourceTickersConfig
                 (new TickerConfig
                     (TickerId, TestTicker, TickerAvailability.AllEnabled, QuoteLevel.Level3, Unknown
-                   , 0.00001m, 0.1m, 100, 0.1m
+                   , 0.000001m, 0.1m, 100, 0.1m
                    , 250, LayerDetails, 20, LastTradedFlags));
         FirstTickerQuoteInfo ??= SourceTickersConfig.GetSourceTickerInfo(ExchangeId, ExchangeName, TestTicker)!;
-        PricingServerConfig ??= new PricingServerConfig(
-                                                        new NetworkTopicConnectionConfig("TestSnapshotServer", SocketConversationProtocol.TcpAcceptor,
-                                                                                         new List<IEndpointConfig>
-                                                                                         {
-                                                                                             new EndpointConfig(TestMachineConfig.LoopBackIpAddress
-                                                                                            , TestMachineConfig.ServerSnapshotPort)
-                                                                                         }, "TestSnapshotServerDescription")
-                                                      , new NetworkTopicConnectionConfig("TestUpdateServer", SocketConversationProtocol.UdpPublisher,
-                                                                                         new List<IEndpointConfig>
-                                                                                         {
-                                                                                             new EndpointConfig(TestMachineConfig.LoopBackIpAddress
-                                                                                            , TestMachineConfig.ServerUpdatePort
-                                                                                            , subnetMask: TestMachineConfig.NetworkSubAddress)
-                                                                                         }, "TestUpdateServerDescription"
-                                                                                       , connectionAttributes: SocketConnectionAttributes.Fast |
-                                                                                         SocketConnectionAttributes.Multicast));
+        PricingServerConfig ??=
+            new PricingServerConfig
+                (new NetworkTopicConnectionConfig
+                     ("TestSnapshotServer", SocketConversationProtocol.TcpAcceptor
+                    , new List<IEndpointConfig>
+                      {
+                          new EndpointConfig(TestMachineConfig.LoopBackIpAddress
+                                           , TestMachineConfig.ServerSnapshotPort)
+                      }, "TestSnapshotServerDescription")
+               , new NetworkTopicConnectionConfig
+                     ("TestUpdateServer", SocketConversationProtocol.UdpPublisher
+                    , new List<IEndpointConfig>
+                      {
+                          new EndpointConfig(TestMachineConfig.LoopBackIpAddress
+                                           , TestMachineConfig.ServerUpdatePort
+                                           , subnetMask: TestMachineConfig.NetworkSubAddress)
+                      }, "TestUpdateServerDescription"
+                    , connectionAttributes: SocketConnectionAttributes.Fast | SocketConnectionAttributes.Multicast));
         DefaultServerMarketConnectionConfig ??= new MarketConnectionConfig(1, ExchangeName, MarketConnectionType.Pricing
                                                                          , SourceTickersConfig, PricingServerConfig);
         DefaultServerMarketsConfig ??= new MarketsConfig("LocalHostPQTestSetupServer", DefaultServerMarketConnectionConfig);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBookTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/LayeredBook/PQOrderBookTests.cs
@@ -71,17 +71,18 @@ public class PQOrderBookTests
         {
             simpleLayers.Add(new PQPriceVolumeLayer(1.234567m, 40_000_000m));
             var sourcePvl =
-                new PQSourcePriceVolumeLayer(nameIdLookupGenerator, 1.234567m, 40_000_000m,
-                                             "TestSourceName", true);
+                new PQSourcePriceVolumeLayer
+                    (nameIdLookupGenerator, 1.234567m, 40_000_000m, "TestSourceName", true);
             sourceLayers.Add(sourcePvl);
-            var srcQtRefPvl = new PQSourceQuoteRefPriceVolumeLayer(nameIdLookupGenerator, 1.234567m, 40_000_000m,
-                                                                   "TestSourceName", true, 12345678u);
+            var srcQtRefPvl = new PQSourceQuoteRefPriceVolumeLayer
+                (nameIdLookupGenerator, 1.234567m, 40_000_000m, "TestSourceName", true, 12345678u);
             sourceQtRefLayers.Add(srcQtRefPvl);
-            valueDateLayers.Add(new PQValueDatePriceVolumeLayer(1.234567m, 40_000_000m,
-                                                                new DateTime(2017, 12, 09, 14, 0, 0)));
-            var allFieldsPvL = new PQSourceQuoteRefTraderValueDatePriceVolumeLayer(nameIdLookupGenerator,
-                                                                                   1.234567m, 40_000_000m, new DateTime(2017, 12, 09, 14, 0, 0),
-                                                                                   "TestSourceName", true, 12345678u);
+            valueDateLayers.Add
+                (new PQValueDatePriceVolumeLayer
+                    (1.234567m, 40_000_000m, new DateTime(2017, 12, 09, 14, 0, 0)));
+            var allFieldsPvL = new PQSourceQuoteRefTraderValueDatePriceVolumeLayer
+                (nameIdLookupGenerator, 1.234567m, 40_000_000m, new DateTime(2017, 12, 09, 14, 0, 0),
+                 "TestSourceName", true, 12345678u);
             allFieldsLayers.Add(allFieldsPvL);
             var traderPvL = new PQTraderPriceVolumeLayer(nameIdLookupGenerator, 1.234567m, 40_000_000m);
             traderLayers.Add(traderPvL);
@@ -109,7 +110,7 @@ public class PQOrderBookTests
             new PQSourceTickerQuoteInfo
                 (new SourceTickerQuoteInfo
                     (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-                   , MaxNumberOfLayers, 0.00001m, 30000m, 50000000m, 1000m, 1
+                   , MaxNumberOfLayers, 0.000001m, 30000m, 50000000m, 1000m, 1
                    , LayerFlags.Volume | LayerFlags.Price
                    , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime));
     }
@@ -396,8 +397,8 @@ public class PQOrderBookTests
         {
             var pqFieldUpdates =
                 populatedOrderBook.GetDeltaUpdateFields
-                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update).ToList();
-            AssertContainsAllOrderBookFields(pqFieldUpdates, populatedOrderBook);
+                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update, publicationPrecisionSettings).ToList();
+            AssertContainsAllOrderBookFields(publicationPrecisionSettings, pqFieldUpdates, populatedOrderBook);
         }
     }
 
@@ -409,9 +410,8 @@ public class PQOrderBookTests
             populatedOrderBook.HasUpdates = false;
             var pqFieldUpdates =
                 populatedOrderBook.GetDeltaUpdateFields
-                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot
-                   , publicationPrecisionSettings).ToList();
-            AssertContainsAllOrderBookFields(pqFieldUpdates, populatedOrderBook);
+                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot, publicationPrecisionSettings).ToList();
+            AssertContainsAllOrderBookFields(publicationPrecisionSettings, pqFieldUpdates, populatedOrderBook);
         }
     }
 
@@ -567,12 +567,13 @@ public class PQOrderBookTests
                      .Where(ob => !ReferenceEquals(ob, originalTypeOrderBook)))
         {
             var emptyOriginalTypeOrderBook = CreateNewEmpty(originalTypeOrderBook);
-            AssertAllLayersAreOfTypeAndEquivalentTo(emptyOriginalTypeOrderBook, originalTypeOrderBook,
-                                                    originalTypeOrderBook[0]!.GetType(), false);
+            AssertAllLayersAreOfTypeAndEquivalentTo
+                (emptyOriginalTypeOrderBook, originalTypeOrderBook
+               , originalTypeOrderBook[0]!.GetType(), false);
             emptyOriginalTypeOrderBook.CopyFrom(otherOrderBook);
-            AssertAllLayersAreOfTypeAndEquivalentTo(emptyOriginalTypeOrderBook, otherOrderBook,
-                                                    GetExpectedType(originalTypeOrderBook[0]!.LayerType,
-                                                                    otherOrderBook[0]!.LayerType));
+            AssertAllLayersAreOfTypeAndEquivalentTo
+                (emptyOriginalTypeOrderBook, otherOrderBook
+               , GetExpectedType(originalTypeOrderBook[0]!.LayerType, otherOrderBook[0]!.LayerType));
         }
     }
 
@@ -587,10 +588,12 @@ public class PQOrderBookTests
             AssertAllLayersAreOfTypeAndEquivalentTo(clonedPopulatedOrderBook, originalTypeOrderBook,
                                                     originalTypeOrderBook[0]!.GetType(), false);
             clonedPopulatedOrderBook.CopyFrom(otherOrderBook);
-            AssertAllLayersAreOfTypeAndEquivalentTo(clonedPopulatedOrderBook, otherOrderBook,
-                                                    GetExpectedType(originalTypeOrderBook[0]!.LayerType, otherOrderBook[0]!.LayerType));
-            AssertAllLayersAreOfTypeAndEquivalentTo(clonedPopulatedOrderBook, originalTypeOrderBook,
-                                                    GetExpectedType(originalTypeOrderBook[0]!.LayerType, otherOrderBook[0]!.LayerType));
+            AssertAllLayersAreOfTypeAndEquivalentTo
+                (clonedPopulatedOrderBook, otherOrderBook
+               , GetExpectedType(originalTypeOrderBook[0]!.LayerType, otherOrderBook[0]!.LayerType));
+            AssertAllLayersAreOfTypeAndEquivalentTo
+                (clonedPopulatedOrderBook, originalTypeOrderBook
+               , GetExpectedType(originalTypeOrderBook[0]!.LayerType, otherOrderBook[0]!.LayerType));
         }
     }
 
@@ -679,13 +682,13 @@ public class PQOrderBookTests
         Assert.AreEqual(0, rt.OfType<IPriceVolumeLayer>().Count());
     }
 
-    public static void AssertAreEquivalentMeetsExpectedExactComparisonType(bool exactComparison,
-        PQOrderBook original, PQOrderBook changingOrderBook, PQLevel2Quote? originalQuote = null,
-        PQLevel2Quote? changingQuote = null)
+    public static void AssertAreEquivalentMeetsExpectedExactComparisonType
+    (bool exactComparison, PQOrderBook original, PQOrderBook changingOrderBook, PQLevel2Quote? originalQuote = null
+      , PQLevel2Quote? changingQuote = null)
     {
         if (original.GetType() == typeof(PQOrderBook))
-            Assert.AreEqual(!exactComparison,
-                            changingOrderBook.AreEquivalent(new OrderBook(original), exactComparison));
+            Assert.AreEqual
+                (!exactComparison, changingOrderBook.AreEquivalent(new OrderBook(original), exactComparison));
 
         Assert.AreEqual(original.AllLayers.Count, changingOrderBook.AllLayers.Count);
 
@@ -730,51 +733,57 @@ public class PQOrderBookTests
         }
     }
 
-    public static void AssertContainsAllOrderBookFields(IList<PQFieldUpdate> checkFieldUpdates,
+    public static void AssertContainsAllOrderBookFields
+    (IPQPriceVolumePublicationPrecisionSettings precisionSettings, IList<PQFieldUpdate> checkFieldUpdates,
         PQOrderBook orderBook)
     {
+        var priceScale  = precisionSettings.PriceScalingPrecision;
+        var volumeScale = precisionSettings.VolumeScalingPrecision;
         for (var i = 0; i < MaxNumberOfLayers; i++)
         {
             var pvl = orderBook[i];
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerPriceOffset + i), pvl!.Price, 1),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerPriceOffset + i), 1)
-                          , $"For layer {pvl.GetType().Name} level {i}");
-            Assert.AreEqual(new PQFieldUpdate((ushort)(PQFieldKeys.LayerVolumeOffset + i), pvl.Volume, 6),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (ushort)(PQFieldKeys.LayerVolumeOffset + i), 6),
-                            $"For bidlayer {pvl.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((byte)(PQFieldKeys.LayerPriceOffset + i), PQScaling.Scale(pvl!.Price, priceScale), priceScale),
+                 PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerPriceOffset + i), priceScale)
+               , $"For layer {pvl.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((ushort)(PQFieldKeys.LayerVolumeOffset + i), PQScaling.Scale(pvl.Volume, volumeScale), volumeScale),
+                 PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (ushort)(PQFieldKeys.LayerVolumeOffset + i), volumeScale),
+                 $"For bidlayer {pvl.GetType().Name} level {i}");
 
             if (pvl is IPQSourcePriceVolumeLayer srcPvl)
             {
-                var srcId = PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerSourceIdOffset + i));
+                var srcId = PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerSourceIdOffset + i));
 
                 var nameIdLookup = srcPvl.NameIdLookup;
 
-                Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerSourceIdOffset + i),
-                                                  nameIdLookup[srcPvl.SourceName!]), srcId);
+                Assert.AreEqual
+                    (new PQFieldUpdate
+                        ((byte)(PQFieldKeys.LayerSourceIdOffset + i), nameIdLookup[srcPvl.SourceName!]), srcId);
             }
 
             if (pvl is IPQSourceQuoteRefPriceVolumeLayer srcQtRefPvl)
             {
-                var srcQtRef = PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                           (byte)(PQFieldKeys.LayerSourceQuoteRefOffset + i));
+                var srcQtRef = PQLevel0QuoteTests.ExtractFieldUpdateWithId
+                    (checkFieldUpdates, (byte)(PQFieldKeys.LayerSourceQuoteRefOffset + i));
 
-                Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerSourceQuoteRefOffset + i),
-                                                  srcQtRefPvl.SourceQuoteReference), srcQtRef);
+                Assert.AreEqual(new PQFieldUpdate
+                                    ((byte)(PQFieldKeys.LayerSourceQuoteRefOffset + i), srcQtRefPvl.SourceQuoteReference), srcQtRef);
             }
 
             if (pvl is IPQValueDatePriceVolumeLayer valueDatePvl)
             {
-                var valueDate = PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                            (ushort)(PQFieldKeys.FirstLayerDateOffset + i));
+                var valueDate = PQLevel0QuoteTests.ExtractFieldUpdateWithId
+                    (checkFieldUpdates, (ushort)(PQFieldKeys.FirstLayerDateOffset + i));
 
                 var dateAsHoursFromEpoch = valueDatePvl.ValueDate.GetHoursFromUnixEpoch();
 
-                Assert.AreEqual(new PQFieldUpdate((ushort)(PQFieldKeys.FirstLayerDateOffset + i),
-                                                  dateAsHoursFromEpoch, PQFieldFlags.IsExtendedFieldId), valueDate);
+                Assert.AreEqual(new PQFieldUpdate
+                                    ((ushort)(PQFieldKeys.FirstLayerDateOffset + i), dateAsHoursFromEpoch, PQFieldFlags.IsExtendedFieldId)
+                              , valueDate);
             }
 
             if (pvl is IPQTraderPriceVolumeLayer bidTrdPvl)
@@ -872,7 +881,8 @@ public class PQOrderBookTests
                };
     }
 
-    private void AssertAllLayersAreOfTypeAndEquivalentTo(PQOrderBook upgradedOrderBook,
+    private void AssertAllLayersAreOfTypeAndEquivalentTo
+    (PQOrderBook upgradedOrderBook,
         PQOrderBook equivalentTo, Type expectedType, bool compareForEquivalence = true,
         bool exactlyEquals = false)
     {
@@ -904,7 +914,8 @@ public class PQOrderBookTests
         for (var i = 0; i < MaxNumberOfLayers; i++) Assert.IsInstanceOfType(orderBook[i], expectedType);
     }
 
-    private static void AssertTraderLayerInfoIsExpected(IList<PQFieldUpdate> checkFieldUpdates,
+    private static void AssertTraderLayerInfoIsExpected
+    (IList<PQFieldUpdate> checkFieldUpdates,
         IPQTraderPriceVolumeLayer traderPvl, int bookIndex, IPQNameIdLookupGenerator nameIdLookup)
     {
         for (var j = 0; j < traderPvl.Count; j++)
@@ -912,21 +923,22 @@ public class PQOrderBookTests
             var trdLayerInfo  = traderPvl[j];
             var fieldPosIndex = (uint)j << 24;
 
-            var traderId = PQLevel2QuoteTests
-                .ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex),
-                                          fieldPosIndex, 0xFF80_0000);
+            var traderId = PQLevel2QuoteTests.ExtractFieldUpdateWithId
+                (checkFieldUpdates, (byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex), fieldPosIndex, 0xFF80_0000);
 
-            var traderVolume = PQLevel2QuoteTests
-                .ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex),
-                                          fieldPosIndex, 0xFF80_0000, 10);
+            var traderVolume =
+                PQLevel2QuoteTests.ExtractFieldUpdateWithId
+                    (checkFieldUpdates, (byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex), fieldPosIndex, 0xFF80_0000, 10);
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex),
-                                              fieldPosIndex | (uint)nameIdLookup[trdLayerInfo!.TraderName!]), traderId);
+            Assert.AreEqual
+                (new PQFieldUpdate
+                    ((byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex), fieldPosIndex | (uint)nameIdLookup[trdLayerInfo!.TraderName!]), traderId);
 
             var value = PQScaling.AutoScale(trdLayerInfo.TraderVolume, 6, out var flag);
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex),
-                                              value | fieldPosIndex, flag), traderVolume);
+            Assert.AreEqual
+                (new PQFieldUpdate
+                    ((byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex), value | fieldPosIndex, flag), traderVolume);
         }
     }
 }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel2QuoteTests.cs
@@ -65,57 +65,55 @@ public class PQLevel2QuoteTests
         simpleSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume | LayerFlags.Price
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         sourceNameSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceName
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         sourceQuoteRefSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceQuoteReference
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         traderDetailsSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize | LayerFlags.TraderCount
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         valueDateSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.ValueDate
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         everyLayerSourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30_000m, 50000000m, 30_000m, 1
                , LayerFlags.Volume.AllFlags()
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
-        simpleEmptyLevel2Quote          = new PQLevel2Quote(simpleSourceTickerQuoteInfo) { HasUpdates = false };
+        simpleEmptyLevel2Quote          = new PQLevel2Quote(new PQSourceTickerQuoteInfo(simpleSourceTickerQuoteInfo)) { HasUpdates = false };
         simpleFullyPopulatedLevel2Quote = new PQLevel2Quote(simpleSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(simpleFullyPopulatedLevel2Quote, 1);
-        sourceNameEmptyLevel2Quote          = new PQLevel2Quote(sourceNameSourceTickerQuoteInfo) { HasUpdates = false };
+        sourceNameEmptyLevel2Quote          = new PQLevel2Quote(new PQSourceTickerQuoteInfo(sourceNameSourceTickerQuoteInfo)) { HasUpdates = false };
         sourceNameFullyPopulatedLevel2Quote = new PQLevel2Quote(sourceNameSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(sourceNameFullyPopulatedLevel2Quote, 2);
-        sourceQuoteRefEmptyLevel2Quote = new PQLevel2Quote(sourceQuoteRefSourceTickerQuoteInfo)
-            { HasUpdates = false };
+        sourceQuoteRefEmptyLevel2Quote = new PQLevel2Quote(new PQSourceTickerQuoteInfo(sourceQuoteRefSourceTickerQuoteInfo)) { HasUpdates = false };
         sourceQuoteRefFullyPopulatedLevel2Quote = new PQLevel2Quote(sourceQuoteRefSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(sourceQuoteRefFullyPopulatedLevel2Quote, 3);
-        traderDetailsEmptyLevel2Quote = new PQLevel2Quote(traderDetailsSourceTickerQuoteInfo)
-            { HasUpdates = false };
+        traderDetailsEmptyLevel2Quote = new PQLevel2Quote(new PQSourceTickerQuoteInfo(traderDetailsSourceTickerQuoteInfo)) { HasUpdates = false };
         traderDetailsFullyPopulatedLevel2Quote = new PQLevel2Quote(traderDetailsSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(traderDetailsFullyPopulatedLevel2Quote, 4);
-        valueDateEmptyLevel2Quote          = new PQLevel2Quote(valueDateSourceTickerQuoteInfo) { HasUpdates = false };
+        valueDateEmptyLevel2Quote          = new PQLevel2Quote(new PQSourceTickerQuoteInfo(valueDateSourceTickerQuoteInfo)) { HasUpdates = false };
         valueDateFullyPopulatedLevel2Quote = new PQLevel2Quote(valueDateSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(valueDateFullyPopulatedLevel2Quote, 5);
-        everyLayerEmptyLevel2Quote          = new PQLevel2Quote(everyLayerSourceTickerQuoteInfo) { HasUpdates = false };
+        everyLayerEmptyLevel2Quote          = new PQLevel2Quote(new PQSourceTickerQuoteInfo(everyLayerSourceTickerQuoteInfo)) { HasUpdates = false };
         everyLayerFullyPopulatedLevel2Quote = new PQLevel2Quote(everyLayerSourceTickerQuoteInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(everyLayerFullyPopulatedLevel2Quote, 5);
 
@@ -362,20 +360,23 @@ public class PQLevel2QuoteTests
             Assert.AreEqual(0, priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
             Assert.AreEqual(2, emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
 
-            var expectedPrice = 200.1234m;
+            var expectedPrice  = 50.1221m;
+            var pqSrcTkrQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+            var priceScale     = pqSrcTkrQtInfo.PriceScalingPrecision;
             priceVolumeLayer.Price = expectedPrice;
             Assert.IsTrue(priceVolumeLayer.IsPriceUpdated);
             Assert.IsTrue(emptyQuote.HasUpdates);
             Assert.AreEqual(expectedPrice, priceVolumeLayer.Price);
             var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
             Assert.AreEqual(3, quoteUpdates.Count);
-            var layerUpdates = priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+            var layerUpdates = priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTkrQtInfo).ToList();
             Assert.AreEqual(1, layerUpdates.Count);
             var expectedLayerField = new PQFieldUpdate(PQFieldKeys.LayerPriceOffset,
-                                                       expectedPrice, 1);
+                                                       PQScaling.Scale(expectedPrice, priceScale), priceScale);
             var expectedSideAdjustedLayerField =
-                new PQFieldUpdate((byte)(PQFieldKeys.LayerPriceOffset + indexFromTop),
-                                  expectedLayerField.Value, (byte)((isBid ? 0 : PQFieldFlags.IsAskSideFlag) | 1));
+                new PQFieldUpdate
+                    ((byte)(PQFieldKeys.LayerPriceOffset + indexFromTop), expectedLayerField.Value
+                   , (byte)((isBid ? 0 : PQFieldFlags.IsAskSideFlag) | expectedLayerField.Flag));
             Assert.AreEqual(expectedLayerField, layerUpdates[0]);
             Assert.AreEqual(expectedSideAdjustedLayerField, quoteUpdates[2]);
 
@@ -431,21 +432,23 @@ public class PQLevel2QuoteTests
             Assert.AreEqual(0, priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
             Assert.AreEqual(2, emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
 
-            var expectedVolume = 40_000_000.12m;
+            var expectedVolume = 40_000_000m;
             priceVolumeLayer.Volume = expectedVolume;
+            var pqSrcTkrQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+            var volumeScale    = pqSrcTkrQtInfo.VolumeScalingPrecision;
             Assert.IsTrue(priceVolumeLayer.IsVolumeUpdated);
             Assert.IsTrue(emptyQuote.HasUpdates);
             Assert.AreEqual(expectedVolume, priceVolumeLayer.Volume);
             var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
             Assert.AreEqual(3, quoteUpdates.Count);
-            var layerUpdates = priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+            var layerUpdates = priceVolumeLayer.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTkrQtInfo).ToList();
             Assert.AreEqual(1, layerUpdates.Count);
             var expectedLayerField = new PQFieldUpdate(PQFieldKeys.LayerVolumeOffset,
-                                                       expectedVolume, 6);
+                                                       PQScaling.Scale(expectedVolume, volumeScale), volumeScale);
             var expectedSideAdjustedLayerField =
                 new PQFieldUpdate
                     ((byte)(PQFieldKeys.LayerVolumeOffset + indexFromTop),
-                     expectedLayerField.Value, (byte)((isBid ? 0 : PQFieldFlags.IsAskSideFlag) | 6));
+                     expectedLayerField.Value, (byte)((isBid ? 0 : PQFieldFlags.IsAskSideFlag) | expectedLayerField.Flag));
             Assert.AreEqual(expectedLayerField, layerUpdates[0]);
             Assert.AreEqual(expectedSideAdjustedLayerField, quoteUpdates[2]);
 
@@ -1064,10 +1067,11 @@ public class PQLevel2QuoteTests
     {
         foreach (var populatedL2Quote in allFullyPopulatedQuotes)
         {
+            var precisionSettings = (PQSourceTickerQuoteInfo)populatedL2Quote.SourceTickerQuoteInfo!;
             var pqFieldUpdates =
                 populatedL2Quote.GetDeltaUpdateFields
-                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update).ToList();
-            AssertContainsAllLevel2Fields(pqFieldUpdates, populatedL2Quote);
+                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update, precisionSettings).ToList();
+            AssertContainsAllLevel2Fields(precisionSettings, pqFieldUpdates, populatedL2Quote);
         }
     }
 
@@ -1085,7 +1089,9 @@ public class PQLevel2QuoteTests
             traderDetailsFullyPopulatedLevel2Quote
                 .GetDeltaUpdateFields
                     (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update).ToList();
-        AssertContainsAllLevel2Fields(pqFieldUpdates, traderDetailsFullyPopulatedLevel2Quote);
+        AssertContainsAllLevel2Fields
+            ((PQSourceTickerQuoteInfo)traderDetailsFullyPopulatedLevel2Quote.SourceTickerQuoteInfo!, pqFieldUpdates
+           , traderDetailsFullyPopulatedLevel2Quote);
     }
 
     [TestMethod]
@@ -1098,7 +1104,9 @@ public class PQLevel2QuoteTests
                 populatedL2Quote
                     .GetDeltaUpdateFields
                         (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot).ToList();
-            AssertContainsAllLevel2Fields(pqFieldUpdates, populatedL2Quote, PQBooleanValuesExtensions.AllFields);
+            AssertContainsAllLevel2Fields
+                ((PQSourceTickerQuoteInfo)populatedL2Quote.SourceTickerQuoteInfo!, pqFieldUpdates
+               , populatedL2Quote, PQBooleanValuesExtensions.AllFields);
         }
     }
 
@@ -1117,7 +1125,9 @@ public class PQLevel2QuoteTests
             traderDetailsFullyPopulatedLevel2Quote
                 .GetDeltaUpdateFields
                     (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot).ToList();
-        AssertContainsAllLevel2Fields(pqFieldUpdates, traderDetailsFullyPopulatedLevel2Quote, PQBooleanValuesExtensions.AllFields);
+        AssertContainsAllLevel2Fields
+            ((PQSourceTickerQuoteInfo)traderDetailsFullyPopulatedLevel2Quote.SourceTickerQuoteInfo!, pqFieldUpdates
+           , traderDetailsFullyPopulatedLevel2Quote, PQBooleanValuesExtensions.AllFields);
     }
 
     [TestMethod]
@@ -1304,7 +1314,8 @@ public class PQLevel2QuoteTests
         }
     }
 
-    public static void AssertAreEquivalentMeetsExpectedExactComparisonType(bool exactComparison,
+    public static void AssertAreEquivalentMeetsExpectedExactComparisonType
+    (bool exactComparison,
         PQLevel2Quote original, PQLevel2Quote changingLevel2Quote)
     {
         PQLevel1QuoteTests.AssertAreEquivalentMeetsExpectedExactComparisonType
@@ -1323,34 +1334,43 @@ public class PQLevel2QuoteTests
              original, changingLevel2Quote);
     }
 
-    public static void AssertContainsAllLevel2Fields(IList<PQFieldUpdate> checkFieldUpdates,
+    public static void AssertContainsAllLevel2Fields
+    (IPQPriceVolumePublicationPrecisionSettings precisionSettings, IList<PQFieldUpdate> checkFieldUpdates,
         PQLevel2Quote l2Q, PQBooleanValues expectedBooleanFlags = PQBooleanValuesExtensions.AllExceptExecutableUpdated)
     {
-        PQLevel1QuoteTests.AssertContainsAllLevel1Fields(checkFieldUpdates, l2Q, expectedBooleanFlags);
+        PQLevel1QuoteTests.AssertContainsAllLevel1Fields(precisionSettings, checkFieldUpdates, l2Q, expectedBooleanFlags);
+
+        var priceScale  = precisionSettings.PriceScalingPrecision;
+        var volumeScale = precisionSettings.VolumeScalingPrecision;
 
         for (var i = 0; i < PQFieldKeys.SingleByteFieldIdMaxBookDepth; i++)
         {
             var bidL2Pvl = l2Q.BidBook[i]!;
             var askL2Pvl = l2Q.AskBook[i]!;
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerPriceOffset + i), bidL2Pvl.Price, 1),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerPriceOffset + i), 1)
+            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerPriceOffset + i), PQScaling.Scale(bidL2Pvl.Price, priceScale), priceScale),
+                            PQLevel0QuoteTests.ExtractFieldUpdateWithId
+                                (checkFieldUpdates, (byte)(PQFieldKeys.LayerPriceOffset + i), priceScale)
                           , $"For bidlayer {bidL2Pvl.GetType().Name} level {i}");
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerPriceOffset + i), askL2Pvl.Price,
-                                              1 | PQFieldFlags.IsAskSideFlag),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerPriceOffset + i), 1 | PQFieldFlags.IsAskSideFlag),
-                            $"For asklayer {bidL2Pvl.GetType().Name} level {i}");
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerVolumeOffset + i), bidL2Pvl.Volume, 6),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerVolumeOffset + i), 6),
-                            $"For bidlayer {bidL2Pvl.GetType().Name} level {i}");
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerVolumeOffset + i), askL2Pvl.Volume,
-                                              6 | PQFieldFlags.IsAskSideFlag),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LayerVolumeOffset + i), 6 | PQFieldFlags.IsAskSideFlag),
-                            $"For asklayer {bidL2Pvl.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((byte)(PQFieldKeys.LayerPriceOffset + i), PQScaling.Scale(askL2Pvl.Price, priceScale)
+                    , (byte)(priceScale | PQFieldFlags.IsAskSideFlag))
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerPriceOffset + i)
+                                                           , (byte)(priceScale | PQFieldFlags.IsAskSideFlag))
+               , $"For asklayer {bidL2Pvl.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((byte)(PQFieldKeys.LayerVolumeOffset + i), PQScaling.Scale(bidL2Pvl.Volume, volumeScale), volumeScale)
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerVolumeOffset + i), volumeScale)
+               , $"For bidlayer {bidL2Pvl.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((byte)(PQFieldKeys.LayerVolumeOffset + i), PQScaling.Scale(askL2Pvl.Volume, volumeScale)
+                    , (byte)(volumeScale | PQFieldFlags.IsAskSideFlag))
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LayerVolumeOffset + i)
+                                                           , (byte)(volumeScale | PQFieldFlags.IsAskSideFlag))
+               , $"For asklayer {bidL2Pvl.GetType().Name} level {i}");
 
             if (bidL2Pvl is IPQSourcePriceVolumeLayer pqBidL2Pvl &&
                 askL2Pvl is IPQSourcePriceVolumeLayer pqAskL2Pvl)
@@ -1375,7 +1395,8 @@ public class PQLevel2QuoteTests
         }
     }
 
-    public static PQFieldUpdate ExtractFieldUpdateWithId(IList<PQFieldUpdate> allUpdates, ushort id,
+    public static PQFieldUpdate ExtractFieldUpdateWithId
+    (IList<PQFieldUpdate> allUpdates, ushort id,
         uint value, uint bitMask, byte flag = 0)
     {
         return allUpdates.First(fu => fu.Id == id && (fu.Value & bitMask) == (value & bitMask) && fu.Flag == flag);
@@ -1391,18 +1412,22 @@ public class PQLevel2QuoteTests
                 switch (level2Quote.BidBook[i])
                 {
                     case PQSourceQuoteRefTraderValueDatePriceVolumeLayer srcQtRefTrdrVlDtPvl:
-                        Assert.IsTrue(ReferenceEquals(((IPQSourcePriceVolumeLayer)level2Quote.BidBook[0]!)
-                                                      .NameIdLookup, srcQtRefTrdrVlDtPvl.NameIdLookup));
-                        Assert.IsTrue(ReferenceEquals(((IPQTraderPriceVolumeLayer)level2Quote.BidBook[0]!)
-                                                      .NameIdLookup, srcQtRefTrdrVlDtPvl.NameIdLookup));
+                        Assert.IsTrue
+                            (ReferenceEquals
+                                (((IPQSourcePriceVolumeLayer)level2Quote.BidBook[0]!).NameIdLookup, srcQtRefTrdrVlDtPvl.NameIdLookup));
+                        Assert.IsTrue
+                            (ReferenceEquals
+                                (((IPQTraderPriceVolumeLayer)level2Quote.BidBook[0]!).NameIdLookup, srcQtRefTrdrVlDtPvl.NameIdLookup));
                         break;
                     case PQSourcePriceVolumeLayer sourcePriceVolumeLayer:
-                        Assert.IsTrue(ReferenceEquals(((IPQSourcePriceVolumeLayer)level2Quote.BidBook[0]!)
-                                                      .NameIdLookup, sourcePriceVolumeLayer.NameIdLookup));
+                        Assert.IsTrue
+                            (ReferenceEquals
+                                (((IPQSourcePriceVolumeLayer)level2Quote.BidBook[0]!).NameIdLookup, sourcePriceVolumeLayer.NameIdLookup));
                         break;
                     case PQTraderPriceVolumeLayer traderPriceVolumeLayer:
-                        Assert.IsTrue(ReferenceEquals(((IPQTraderPriceVolumeLayer)level2Quote.BidBook[0]!)
-                                                      .NameIdLookup, traderPriceVolumeLayer.NameIdLookup));
+                        Assert.IsTrue
+                            (ReferenceEquals
+                                (((IPQTraderPriceVolumeLayer)level2Quote.BidBook[0]!).NameIdLookup, traderPriceVolumeLayer.NameIdLookup));
                         break;
                 }
             }
@@ -1435,7 +1460,8 @@ public class PQLevel2QuoteTests
         if (pvl is IPQTraderPriceVolumeLayer traderPvl) Assert.AreEqual(0, traderPvl.Count);
     }
 
-    private static void AssertSourceContainsAllFields(IList<PQFieldUpdate> checkFieldUpdates, int i,
+    private static void AssertSourceContainsAllFields
+    (IList<PQFieldUpdate> checkFieldUpdates, int i,
         IPQSourcePriceVolumeLayer pqBidL2Pvl,
         IPQSourcePriceVolumeLayer pqAskL2Pvl)
     {
@@ -1446,11 +1472,13 @@ public class PQLevel2QuoteTests
                 (checkFieldUpdates, (byte)(PQFieldKeys.LayerSourceIdOffset + i), PQFieldFlags.IsAskSideFlag);
 
         var bidNameIdLookup = pqBidL2Pvl.NameIdLookup;
-        Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerSourceIdOffset + i),
-                                          bidNameIdLookup[pqBidL2Pvl.SourceName!]), bidSrcId);
+        Assert.AreEqual
+            (new PQFieldUpdate
+                ((byte)(PQFieldKeys.LayerSourceIdOffset + i), bidNameIdLookup[pqBidL2Pvl.SourceName!]), bidSrcId);
         var askNameIdLookup = pqAskL2Pvl.NameIdLookup;
-        Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerSourceIdOffset + i),
-                                          askNameIdLookup[pqAskL2Pvl.SourceName!], PQFieldFlags.IsAskSideFlag), askSrcId);
+        Assert.AreEqual
+            (new PQFieldUpdate
+                ((byte)(PQFieldKeys.LayerSourceIdOffset + i), askNameIdLookup[pqAskL2Pvl.SourceName!], PQFieldFlags.IsAskSideFlag), askSrcId);
 
         var bidSrcExecutable =
             PQLevel0QuoteTests.ExtractFieldUpdateWithId
@@ -1459,14 +1487,17 @@ public class PQLevel2QuoteTests
             PQLevel0QuoteTests.ExtractFieldUpdateWithId
                 (checkFieldUpdates, (byte)(PQFieldKeys.LayerBooleanFlagsOffset + i), PQFieldFlags.IsAskSideFlag);
 
-        Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerBooleanFlagsOffset + i),
-                                          pqBidL2Pvl.Executable ? PQFieldFlags.LayerExecutableFlag : 0), bidSrcExecutable);
-        Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerBooleanFlagsOffset + i),
-                                          pqBidL2Pvl.Executable ? PQFieldFlags.LayerExecutableFlag : 0,
-                                          PQFieldFlags.IsAskSideFlag), askSrcExecutable);
+        Assert.AreEqual
+            (new PQFieldUpdate
+                ((byte)(PQFieldKeys.LayerBooleanFlagsOffset + i), pqBidL2Pvl.Executable ? PQFieldFlags.LayerExecutableFlag : 0), bidSrcExecutable);
+        Assert.AreEqual
+            (new PQFieldUpdate
+                ((byte)(PQFieldKeys.LayerBooleanFlagsOffset + i), pqBidL2Pvl.Executable ? PQFieldFlags.LayerExecutableFlag : 0
+               , PQFieldFlags.IsAskSideFlag), askSrcExecutable);
     }
 
-    private static void AssertSourceQuoteRefContainsAllFields(IList<PQFieldUpdate> checkFieldUpdates, int i,
+    private static void AssertSourceQuoteRefContainsAllFields
+    (IList<PQFieldUpdate> checkFieldUpdates, int i,
         IPQSourceQuoteRefPriceVolumeLayer bidSrcQtRefPvl, IPQSourceQuoteRefPriceVolumeLayer askSrcQtRefPvl)
     {
         var bidSrcQtRef =
@@ -1482,7 +1513,8 @@ public class PQLevel2QuoteTests
                                           askSrcQtRefPvl.SourceQuoteReference, PQFieldFlags.IsAskSideFlag), askSrcQtRef);
     }
 
-    private static void AssertValueDateLayerContainsAllFields(IList<PQFieldUpdate> checkFieldUpdates, int i,
+    private static void AssertValueDateLayerContainsAllFields
+    (IList<PQFieldUpdate> checkFieldUpdates, int i,
         IPQValueDatePriceVolumeLayer bidValueDatePvl, IPQValueDatePriceVolumeLayer askValueDatePvl)
     {
         var bidValueDate =
@@ -1501,7 +1533,8 @@ public class PQLevel2QuoteTests
                                           dateAsHoursFromEpoch, PQFieldFlags.IsAskSideFlag | PQFieldFlags.IsExtendedFieldId), askValueDate);
     }
 
-    private static void AssertTraderLayerInfoIsExpected(IList<PQFieldUpdate> checkFieldUpdates,
+    private static void AssertTraderLayerInfoIsExpected
+    (IList<PQFieldUpdate> checkFieldUpdates,
         IPQTraderPriceVolumeLayer traderPvl, bool isAskSide, int bookIndex, IPQNameIdLookupGenerator nameIdLookup)
     {
         for (var j = 0; j < traderPvl.Count; j++)
@@ -1511,12 +1544,13 @@ public class PQLevel2QuoteTests
 
             if (trdLayerInfo.TraderName == PQTraderPriceVolumeLayer.TraderCountOnlyName)
             {
-                Assert.AreEqual(new PQFieldUpdate((ushort)(PQFieldKeys.LayerTraderIdOffset + bookIndex),
-                                                  0x0080_0000 | traderPvl.Count, isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0),
-                                ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                         (ushort)(PQFieldKeys.LayerTraderIdOffset + bookIndex), 0x0080_0000, 0x0080_0000,
-                                                         isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0),
-                                $"For {traderPvl.GetType().Name} ");
+                Assert.AreEqual
+                    (new PQFieldUpdate
+                         ((ushort)(PQFieldKeys.LayerTraderIdOffset + bookIndex), 0x0080_0000 | traderPvl.Count
+                        , isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0)
+                   , ExtractFieldUpdateWithId(checkFieldUpdates, (ushort)(PQFieldKeys.LayerTraderIdOffset + bookIndex), 0x0080_0000, 0x0080_0000
+                                            , isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0)
+                   , $"For {traderPvl.GetType().Name} ");
                 return;
             }
 
@@ -1530,14 +1564,16 @@ public class PQLevel2QuoteTests
                     (checkFieldUpdates, (byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex), fieldPosIndex, 0xFF80_0000,
                      (byte)(08 | (isAskSide ? PQFieldFlags.IsAskSideFlag : 0)));
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex),
-                                              fieldPosIndex | (uint)nameIdLookup[trdLayerInfo.TraderName!],
-                                              isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0), traderId);
+            Assert.AreEqual
+                (new PQFieldUpdate
+                    ((byte)(PQFieldKeys.LayerTraderIdOffset + bookIndex), fieldPosIndex | (uint)nameIdLookup[trdLayerInfo.TraderName!]
+                   , isAskSide ? PQFieldFlags.IsAskSideFlag : (byte)0), traderId);
 
             var value = PQScaling.AutoScale(trdLayerInfo.TraderVolume, 6, out var flag);
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex),
-                                              value | fieldPosIndex,
-                                              (byte)(flag | (isAskSide ? PQFieldFlags.IsAskSideFlag : 0))), traderVolume);
+            Assert.AreEqual
+                (new PQFieldUpdate
+                    ((byte)(PQFieldKeys.LayerTraderVolumeOffset + bookIndex), value | fieldPosIndex
+                   , (byte)(flag | (isAskSide ? PQFieldFlags.IsAskSideFlag : 0))), traderVolume);
         }
     }
 }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3QuoteTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Messages/Quotes/PQLevel3QuoteTests.cs
@@ -63,20 +63,20 @@ public class PQLevel3QuoteTests
         noRecentlyTradedSrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 3000m, 50000000m, 30000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
                | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference, LastTradedFlags.None);
         simpleRecentlyTradedSrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 3000m, 50000000m, 30000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
                | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference,
                  LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice);
         paidGivenVolumeRecentlyTradedSrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 3000m, 50000000m, 30000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
                | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference
                , LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice
@@ -84,20 +84,20 @@ public class PQLevel3QuoteTests
         traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 3000m, 50000000m, 30000m, 1
                , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize
                | LayerFlags.ValueDate | LayerFlags.TraderCount | LayerFlags.SourceQuoteReference
                , LastTradedFlags.LastTradedTime | LastTradedFlags.LastTradedPrice | LastTradedFlags.TraderName);
-        noRecentlyTradedEmptyQuote          = new PQLevel3Quote(noRecentlyTradedSrcTkrQtInfo) { HasUpdates = false };
+        noRecentlyTradedEmptyQuote          = new PQLevel3Quote(new PQSourceTickerQuoteInfo(noRecentlyTradedSrcTkrQtInfo)) { HasUpdates = false };
         noRecentlyTradedFullyPopulatedQuote = new PQLevel3Quote(noRecentlyTradedSrcTkrQtInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(noRecentlyTradedFullyPopulatedQuote, 9);
-        simpleRecentlyTradedEmptyQuote = new PQLevel3Quote(simpleRecentlyTradedSrcTkrQtInfo)
+        simpleRecentlyTradedEmptyQuote = new PQLevel3Quote(new PQSourceTickerQuoteInfo(simpleRecentlyTradedSrcTkrQtInfo))
         {
             HasUpdates = false
         };
         simpleRecentlyTradedFullyPopulatedQuote = new PQLevel3Quote(simpleRecentlyTradedSrcTkrQtInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(simpleRecentlyTradedFullyPopulatedQuote, 10);
-        paidGivenVolumeRecentlyTradedEmptyQuote = new PQLevel3Quote(paidGivenVolumeRecentlyTradedSrcTkrQtInfo)
+        paidGivenVolumeRecentlyTradedEmptyQuote = new PQLevel3Quote(new PQSourceTickerQuoteInfo(paidGivenVolumeRecentlyTradedSrcTkrQtInfo))
         {
             HasUpdates = false
         };
@@ -105,7 +105,7 @@ public class PQLevel3QuoteTests
             new PQLevel3Quote(paidGivenVolumeRecentlyTradedSrcTkrQtInfo);
         quoteSequencedTestDataBuilder.InitializeQuote(paidGivenVolumeRecentlyTradedFullyPopulatedQuote, 10);
         traderPaidGivenVolumeRecentlyTradedEmptyQuote =
-            new PQLevel3Quote(traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo) { HasUpdates = false };
+            new PQLevel3Quote(new PQSourceTickerQuoteInfo(traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo)) { HasUpdates = false };
         traderPaidGivenVolumeRecentlyTradedFullyPopulatedQuote =
             new PQLevel3Quote(traderPaidGivenVolumeRecentlyTradedSrcTkrQtInfo);
         quoteSequencedTestDataBuilder
@@ -294,19 +294,22 @@ public class PQLevel3QuoteTests
                 Assert.AreEqual(0, lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
                 Assert.AreEqual(2, emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
 
-                var expectedPrice = 200.1234m;
+                var expectedPrice  = 50.1234m;
+                var pqSrcTrkQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+                var priceScale     = pqSrcTrkQtInfo.PriceScalingPrecision;
                 lastTrade.TradePrice = expectedPrice;
                 Assert.IsTrue(lastTrade.IsTradePriceUpdated);
                 Assert.IsTrue(emptyQuote.HasUpdates);
                 Assert.AreEqual(expectedPrice, lastTrade.TradePrice);
                 var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
                 Assert.AreEqual(3, quoteUpdates.Count);
-                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTrkQtInfo).ToList();
                 Assert.AreEqual(1, lastTradeUpdates.Count);
-                var expectedLastTradeField = new PQFieldUpdate(PQFieldKeys.LastTradePriceOffset, expectedPrice, 1);
+                var expectedLastTradeField
+                    = new PQFieldUpdate(PQFieldKeys.LastTradePriceOffset, PQScaling.Scale(expectedPrice, priceScale), priceScale);
                 var expectedQuoteLastTradeField =
                     new PQFieldUpdate
-                        ((byte)(PQFieldKeys.LastTradePriceOffset + i), expectedLastTradeField.Value, 1);
+                        ((byte)(PQFieldKeys.LastTradePriceOffset + i), expectedLastTradeField.Value, expectedLastTradeField.Flag);
                 Assert.AreEqual(expectedLastTradeField, lastTradeUpdates[0]);
                 Assert.AreEqual(expectedQuoteLastTradeField, quoteUpdates[2]);
 
@@ -449,18 +452,20 @@ public class PQLevel3QuoteTests
 
                 const bool expectedWasGiven = true;
                 lastTrade.WasGiven = expectedWasGiven;
+                var pqSrcTrkQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+                var volumeScale    = pqSrcTrkQtInfo.VolumeScalingPrecision;
                 Assert.IsTrue(lastTrade.IsWasGivenUpdated);
                 Assert.IsTrue(emptyQuote.HasUpdates);
                 Assert.AreEqual(expectedWasGiven, lastTrade.WasGiven);
                 var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
                 Assert.AreEqual(3, quoteUpdates.Count);
-                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTrkQtInfo).ToList();
                 Assert.AreEqual(1, lastTradeUpdates.Count);
                 var expectedLastTradeField = new PQFieldUpdate(PQFieldKeys.LastTradeVolumeOffset,
-                                                               0, PQFieldFlags.IsGivenFlag | 6);
+                                                               0, (byte)(PQFieldFlags.IsGivenFlag | volumeScale));
                 var expectedQuoteLastTradeField = new PQFieldUpdate(
                                                                     (byte)(PQFieldKeys.LastTradeVolumeOffset + i),
-                                                                    0, PQFieldFlags.IsGivenFlag | 6);
+                                                                    0, (byte)(PQFieldFlags.IsGivenFlag | volumeScale));
                 Assert.AreEqual(expectedLastTradeField, lastTradeUpdates[0]);
                 Assert.AreEqual(expectedQuoteLastTradeField, quoteUpdates[2]);
 
@@ -512,18 +517,20 @@ public class PQLevel3QuoteTests
 
                 const bool expectedWasPaid = true;
                 lastTrade.WasPaid = expectedWasPaid;
+                var pqSrcTrkQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+                var volumeScale    = pqSrcTrkQtInfo.VolumeScalingPrecision;
                 Assert.IsTrue(lastTrade.IsWasPaidUpdated);
                 Assert.IsTrue(emptyQuote.HasUpdates);
                 Assert.AreEqual(expectedWasPaid, lastTrade.WasPaid);
                 var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
                 Assert.AreEqual(3, quoteUpdates.Count);
-                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTrkQtInfo).ToList();
                 Assert.AreEqual(1, lastTradeUpdates.Count);
                 var expectedLastTradeField =
-                    new PQFieldUpdate(PQFieldKeys.LastTradeVolumeOffset, 0, PQFieldFlags.IsPaidFlag | 6);
+                    new PQFieldUpdate(PQFieldKeys.LastTradeVolumeOffset, 0, (byte)(PQFieldFlags.IsPaidFlag | volumeScale));
                 var expectedQuoteLastTradeField =
                     new PQFieldUpdate((byte)(PQFieldKeys.LastTradeVolumeOffset + i),
-                                      0, PQFieldFlags.IsPaidFlag | 6);
+                                      0, (byte)(PQFieldFlags.IsPaidFlag | volumeScale));
                 Assert.AreEqual(expectedLastTradeField, lastTradeUpdates[0]);
                 Assert.AreEqual(expectedQuoteLastTradeField, quoteUpdates[2]);
 
@@ -573,19 +580,21 @@ public class PQLevel3QuoteTests
                 Assert.AreEqual(0, lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
                 Assert.AreEqual(2, emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).Count());
 
-                var expectedVolume = 42_111_333m;
+                var expectedVolume = 42_130_000m;
+                var pqSrcTrkQtInfo = (PQSourceTickerQuoteInfo)emptyQuote.SourceTickerQuoteInfo!;
+                var volumeScale    = pqSrcTrkQtInfo.VolumeScalingPrecision;
                 lastTrade.TradeVolume = expectedVolume;
                 Assert.IsTrue(lastTrade.IsTradeVolumeUpdated);
                 Assert.IsTrue(emptyQuote.HasUpdates);
                 Assert.AreEqual(expectedVolume, lastTrade.TradeVolume);
                 var quoteUpdates = emptyQuote.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
                 Assert.AreEqual(3, quoteUpdates.Count);
-                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update).ToList();
+                var lastTradeUpdates = lastTrade.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pqSrcTrkQtInfo).ToList();
                 Assert.AreEqual(1, lastTradeUpdates.Count);
                 var expectedLastTradeField =
-                    new PQFieldUpdate(PQFieldKeys.LastTradeVolumeOffset, expectedVolume, 6);
+                    new PQFieldUpdate(PQFieldKeys.LastTradeVolumeOffset, PQScaling.Scale(expectedVolume, volumeScale), volumeScale);
                 var expectedQuoteLastTradeField =
-                    new PQFieldUpdate((byte)(PQFieldKeys.LastTradeVolumeOffset + i), expectedLastTradeField.Value, 6);
+                    new PQFieldUpdate((byte)(PQFieldKeys.LastTradeVolumeOffset + i), expectedLastTradeField.Value, expectedLastTradeField.Flag);
                 Assert.AreEqual(expectedLastTradeField, lastTradeUpdates[0]);
                 Assert.AreEqual(expectedQuoteLastTradeField, quoteUpdates[2]);
 
@@ -729,11 +738,12 @@ public class PQLevel3QuoteTests
     {
         foreach (var populatedL3Quote in allFullyPopulatedQuotes)
         {
+            var precisionSettings = (PQSourceTickerQuoteInfo)populatedL3Quote.SourceTickerQuoteInfo!;
             var pqFieldUpdates =
                 populatedL3Quote.GetDeltaUpdateFields
-                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update).ToList();
+                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Update, precisionSettings).ToList();
             AssertContainsAllLevel3Fields
-                (pqFieldUpdates, populatedL3Quote,
+                (precisionSettings, pqFieldUpdates, populatedL3Quote,
                  PQBooleanValuesExtensions
                      .AllExceptExecutableUpdated
                      .Unset
@@ -751,12 +761,13 @@ public class PQLevel3QuoteTests
     {
         foreach (var populatedL3Quote in allFullyPopulatedQuotes)
         {
+            var precisionSettings = (PQSourceTickerQuoteInfo)populatedL3Quote.SourceTickerQuoteInfo!;
             populatedL3Quote.HasUpdates = false;
             var pqFieldUpdates =
                 populatedL3Quote.GetDeltaUpdateFields
-                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot).ToList();
+                    (new DateTime(2017, 11, 04, 12, 33, 1), StorageFlags.Snapshot, precisionSettings).ToList();
             AssertContainsAllLevel3Fields
-                (pqFieldUpdates, populatedL3Quote,
+                (precisionSettings, pqFieldUpdates, populatedL3Quote,
                  PQBooleanValuesExtensions
                      .AllFields
                      .Unset
@@ -811,6 +822,7 @@ public class PQLevel3QuoteTests
             // not copied from field updates as is used in by server to track publication times.
             newEmpty.PQSequenceId        = populatedL3Quote.PQSequenceId;
             newEmpty.LastPublicationTime = populatedL3Quote.LastPublicationTime;
+            Console.WriteLine(populatedL3Quote.DiffQuotes(newEmpty));
             Assert.AreEqual(populatedL3Quote, newEmpty);
         }
     }
@@ -955,8 +967,8 @@ public class PQLevel3QuoteTests
         }
     }
 
-    public static void AssertAreEquivalentMeetsExpectedExactComparisonType(bool exactComparison,
-        PQLevel3Quote original, PQLevel3Quote changingLevel3Quote)
+    public static void AssertAreEquivalentMeetsExpectedExactComparisonType
+        (bool exactComparison, PQLevel3Quote original, PQLevel3Quote changingLevel3Quote)
     {
         PQLevel1QuoteTests.AssertAreEquivalentMeetsExpectedExactComparisonType(exactComparison, original, changingLevel3Quote);
 
@@ -987,10 +999,11 @@ public class PQLevel3QuoteTests
                  original, changingLevel3Quote);
     }
 
-    public static void AssertContainsAllLevel3Fields(IList<PQFieldUpdate> checkFieldUpdates,
+    public static void AssertContainsAllLevel3Fields
+    (IPQPriceVolumePublicationPrecisionSettings precisionSettings, IList<PQFieldUpdate> checkFieldUpdates,
         PQLevel3Quote l3Q, PQBooleanValues expectedBooleanFlags = PQBooleanValuesExtensions.AllExceptExecutableUpdated)
     {
-        PQLevel2QuoteTests.AssertContainsAllLevel2Fields(checkFieldUpdates, l3Q, expectedBooleanFlags);
+        PQLevel2QuoteTests.AssertContainsAllLevel2Fields(precisionSettings, checkFieldUpdates, l3Q, expectedBooleanFlags);
 
         Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.BatchId, l3Q.BatchId),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.BatchId));
@@ -999,47 +1012,46 @@ public class PQLevel3QuoteTests
         Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.ValueDate, l3Q.ValueDate.GetHoursFromUnixEpoch()),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.ValueDate));
         if (l3Q.RecentlyTraded == null) return;
+        var priceScale  = precisionSettings.PriceScalingPrecision;
+        var volumeScale = precisionSettings.VolumeScalingPrecision;
         for (var i = 0; i < PQFieldKeys.SingleByteFieldIdMaxPossibleLastTrades; i++)
         {
             var lastTrade = l3Q.RecentlyTraded[i]!;
 
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LastTradePriceOffset + i), lastTrade.TradePrice,
-                                              1), PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                                              (byte)(PQFieldKeys.LastTradePriceOffset + i), 1),
-                            $"For lastTradeType {lastTrade.GetType().Name} level {i}");
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LastTradeTimeHourOffset + i),
-                                              lastTrade.TradeTime.GetHoursFromUnixEpoch()),
-                            PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                        (byte)(PQFieldKeys.LastTradeTimeHourOffset + i)),
-                            $"For bidlayer {lastTrade.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate
+                     ((byte)(PQFieldKeys.LastTradePriceOffset + i), PQScaling.Scale(lastTrade.TradePrice, priceScale), priceScale)
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LastTradePriceOffset + i), priceScale)
+               , $"For lastTradeType {lastTrade.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate((byte)(PQFieldKeys.LastTradeTimeHourOffset + i), lastTrade.TradeTime.GetHoursFromUnixEpoch())
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LastTradeTimeHourOffset + i))
+               , $"For bidlayer {lastTrade.GetType().Name} level {i}");
             var flag = lastTrade.TradeTime.GetSubHourComponent().BreakLongToByteAndUint(out var subHourBase);
-            Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LastTradeTimeSubHourOffset + i), subHourBase,
-                                              flag), PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                                                 (byte)(PQFieldKeys.LastTradeTimeSubHourOffset + i)
-                                                                                               , flag),
-                            $"For asklayer {lastTrade.GetType().Name} level {i}");
+            Assert.AreEqual
+                (new PQFieldUpdate((byte)(PQFieldKeys.LastTradeTimeSubHourOffset + i), subHourBase, flag)
+               , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LastTradeTimeSubHourOffset + i), flag)
+               , $"For asklayer {lastTrade.GetType().Name} level {i}");
 
             if (lastTrade is IPQLastPaidGivenTrade pqPaidGivenTrade)
             {
                 byte noVal        = 0;
-                var  expectedFlag = pqPaidGivenTrade.WasGiven ? PQFieldFlags.IsGivenFlag : noVal;
+                var  expectedFlag = (byte)(volumeScale | (pqPaidGivenTrade.WasGiven ? PQFieldFlags.IsGivenFlag : noVal));
                 expectedFlag |= pqPaidGivenTrade.WasPaid ? PQFieldFlags.IsPaidFlag : noVal;
-                expectedFlag |= (byte)(expectedFlag | 6);
 
 
-                Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LastTradeVolumeOffset + i),
-                                                  pqPaidGivenTrade.TradeVolume, expectedFlag),
-                                PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                            (byte)(PQFieldKeys.LastTradeVolumeOffset + i), expectedFlag),
-                                $"For asklayer {lastTrade.GetType().Name} level {i}");
+                Assert.AreEqual
+                    (new PQFieldUpdate
+                         ((byte)(PQFieldKeys.LastTradeVolumeOffset + i), PQScaling.Scale(pqPaidGivenTrade.TradeVolume, volumeScale), expectedFlag)
+                   , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LastTradeVolumeOffset + i), expectedFlag)
+                   , $"For asklayer {lastTrade.GetType().Name} level {i}");
             }
 
             if (lastTrade is IPQLastTraderPaidGivenTrade pqTraderPaidGivenTrade)
-                Assert.AreEqual(new PQFieldUpdate((byte)(PQFieldKeys.LastTraderIdOffset + i),
-                                                  pqTraderPaidGivenTrade.TraderId),
-                                PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates,
-                                                                            (byte)(PQFieldKeys.LastTraderIdOffset + i)),
-                                $"For asklayer {lastTrade.GetType().Name} level {i}");
+                Assert.AreEqual
+                    (new PQFieldUpdate((byte)(PQFieldKeys.LastTraderIdOffset + i), pqTraderPaidGivenTrade.TraderId)
+                   , PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, (byte)(PQFieldKeys.LastTraderIdOffset + i))
+                   , $"For asklayer {lastTrade.GetType().Name} level {i}");
         }
     }
 

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerBaseTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerBaseTests.cs
@@ -91,7 +91,7 @@ public class PQQuoteDeserializerBaseTests
         sourceTickerQuoteInfo =
             new SourceTickerQuoteInfo
                 (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", QuoteLevel.Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1
                , LayerFlags.Volume | LayerFlags.Price
                , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
 
@@ -118,8 +118,8 @@ public class PQQuoteDeserializerBaseTests
     public void TearDown()
     {
         var realInstance =
-            PerfLoggingPoolFactory.Instance.GetLatencyTracingLoggerPool("clientCallback",
-                                                                        TimeSpan.FromMilliseconds(10), typeof(UserCallback));
+            PerfLoggingPoolFactory.Instance.GetLatencyTracingLoggerPool
+                ("clientCallback", TimeSpan.FromMilliseconds(10), typeof(UserCallback));
 
         NonPublicInvocator.SetStaticField
             (dummyLevel0QuoteDeserializer, "PublishPQQuoteDeserializerLatencyTraceLoggerPool", realInstance);
@@ -347,7 +347,8 @@ public class PQQuoteDeserializerBaseTests
     public void EmptyQuoteLvl2Quote_UpdateQuote_SetsDispatcherContextDetails()
     {
         var expectedL2Quote = new PQLevel2Quote(sourceTickerQuoteInfo);
-        var numLayers       = expectedL2Quote.BidBook.Capacity;
+
+        var numLayers = expectedL2Quote.BidBook.Capacity;
         Assert.IsTrue(numLayers >= 20);
         for (var i = 0; i < numLayers; i++)
         {
@@ -387,7 +388,8 @@ public class PQQuoteDeserializerBaseTests
     [TestMethod]
     public void EmptyQuoteLvl3Quote_UpdateQuote_SetsDispatcherContextDetails()
     {
-        var expectedL3Quote           = new PQLevel3Quote(sourceTickerQuoteInfo);
+        var expectedL3Quote = new PQLevel3Quote(sourceTickerQuoteInfo);
+
         var deepestPossibleLayerIndex = expectedL3Quote.BidBook.Capacity;
         Assert.IsTrue(deepestPossibleLayerIndex >= 20);
         var toggleGivenBool = false;
@@ -658,8 +660,7 @@ public class PQQuoteDeserializerBaseTests
             UpdateQuote(socketBufferReadContext, ent, sequenceId);
         }
 
-        public void InvokePushQuoteToSubscribers(PQSyncStatus syncStatus,
-            IPerfLogger? detectionToPublishLatencyTraceLogger = null)
+        public void InvokePushQuoteToSubscribers(PQSyncStatus syncStatus, IPerfLogger? detectionToPublishLatencyTraceLogger = null)
         {
             PushQuoteToSubscribers(syncStatus, detectionToPublishLatencyTraceLogger);
         }

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Deserialization/PQQuoteDeserializerTests.cs
@@ -76,7 +76,7 @@ public class PQQuoteDeserializerTests
     {
         sourceTickerQuoteInfo = new SourceTickerQuoteInfo
             (ushort.MaxValue, "TestSource", ushort.MaxValue, "TestTicker", Level3, Unknown
-           , 20, 0.00001m, 30000m, 50000000m, 1000m, 1
+           , 20, 0.000001m, 30000m, 50000000m, 1000m, 1
            , LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName | LayerFlags.TraderSize | LayerFlags.TraderCount
            , LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                          | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Serdes/Serialization/PQQuoteSerializerTests.cs
@@ -75,44 +75,44 @@ public class PQQuoteSerializerTests
         level0QuoteInfo =
             new SourceTickerQuoteInfo
                 (1, "TestSource1", 1, "TestTicker1", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1);
         level1QuoteInfo =
             new SourceTickerQuoteInfo
                 (2, "TestSource2", 2, "TestTicker2", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1);
         valueDateQuoteInfo =
             new SourceTickerQuoteInfo
                 (7, "TestSource", 7, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1,
                  LayerFlags.Volume | LayerFlags.Price | LayerFlags.ValueDate,
                  LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                              | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         everyLayerQuoteInfo =
             new SourceTickerQuoteInfo
                 (8, "TestSource", 8, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1,
                  LayerFlags.Volume.AllFlags(),
                  LastTradedFlags.PaidOrGiven | LastTradedFlags.TraderName
                                              | LastTradedFlags.LastTradedVolume | LastTradedFlags.LastTradedTime);
         simpleNoRecentlyTradedQuoteInfo
             = new SourceTickerQuoteInfo
                 (3, "TestSource", 3, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1);
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1);
         srcNmLstTrdQuoteInfo =
             new SourceTickerQuoteInfo
                 (4, "TestSource", 4, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1,
                  LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceName
                , LastTradedFlags.LastTradedPrice | LastTradedFlags.LastTradedTime);
         srcQtRfPdGvnVlmQuoteInfo =
             new SourceTickerQuoteInfo
                 (5, "TestSource", 5, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1,
                  LayerFlags.Volume | LayerFlags.Price | LayerFlags.SourceQuoteReference, LastTradedFlags.PaidOrGiven);
         trdrLyrTrdrPdGvnVlmDtlsQuoteInfo =
             new SourceTickerQuoteInfo
                 (6, "TestSource", 6, "TestTicker", Level3, Unknown
-               , 20, 0.00001m, 30000m, 50000000m, 1000m, 1,
+               , 20, 0.000001m, 30000m, 50000000m, 1000m, 1,
                  LayerFlags.Volume | LayerFlags.Price | LayerFlags.TraderName
                | LayerFlags.TraderSize | LayerFlags.TraderCount, LastTradedFlags.TraderName);
         level0Quote       = new PQLevel0Quote(level0QuoteInfo);
@@ -318,7 +318,8 @@ public class PQQuoteSerializerTests
         }
     }
 
-    private unsafe void AssertExpectedBytesWriten(int amtWritten, bool isSnapshot,
+    private unsafe void AssertExpectedBytesWriten
+    (int amtWritten, bool isSnapshot,
         List<PQFieldUpdate> expectedFieldUpdates, List<PQFieldStringUpdate> expectedStringUpdates,
         IPQLevel0Quote originalQuote)
     {

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Summaries/PQPricePeriodSummaryTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/Summaries/PQPricePeriodSummaryTests.cs
@@ -176,10 +176,11 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsStartBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.StartBidPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedStartBidPrice = 1.2345678m;
+        var expectedStartBidPrice = 1.23456m;
+        var scaleFactor           = PQScaling.FindScaleFactor(expectedStartBidPrice - 1);
         emptySummary.StartBidPrice = expectedStartBidPrice;
         Assert.IsTrue(emptySummary.IsStartBidPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
@@ -187,19 +188,19 @@ public class PQPricePeriodSummaryTests
         var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
                                                               pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodStartPrice, expectedStartBidPrice, 1);
+        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodStartPrice, expectedStartBidPrice, scaleFactor);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsStartBidPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsStartBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue
+            (emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodStartPrice
-               && update.Flag == 1
+               && update.Flag == scaleFactor
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -216,10 +217,11 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsStartAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.StartAskPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedStartAskPrice = 1.2345678m;
+        var expectedStartAskPrice = 1.23456m;
+        var scaleFactor           = PQScaling.FindScaleFactor(expectedStartAskPrice - 1);
         emptySummary.StartAskPrice = expectedStartAskPrice;
         Assert.IsTrue(emptySummary.IsStartAskPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
@@ -227,20 +229,20 @@ public class PQPricePeriodSummaryTests
         var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
                                                               pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodStartPrice, expectedStartAskPrice,
-                                                    1 | PQFieldFlags.IsAskSideFlag);
+        var expectedFieldUpdate = new PQFieldUpdate
+            (PQFieldKeys.PeriodStartPrice, expectedStartAskPrice, (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag));
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsStartAskPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsStartAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue
+            (emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodStartPrice
-               && update.Flag == (1 | PQFieldFlags.IsAskSideFlag)
+               && update.Flag == (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag)
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -257,10 +259,11 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsHighestBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.HighestBidPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedHighestBidPrice = 1.2345678m;
+        var expectedHighestBidPrice = 1.23456m;
+        var scaleFactor             = PQScaling.FindScaleFactor(expectedHighestBidPrice - 1);
         emptySummary.HighestBidPrice = expectedHighestBidPrice;
         Assert.IsTrue(emptySummary.IsHighestBidPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
@@ -268,19 +271,19 @@ public class PQPricePeriodSummaryTests
         var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
                                                               pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodHighestPrice, expectedHighestBidPrice, 1);
+        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodHighestPrice, expectedHighestBidPrice, scaleFactor);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsHighestBidPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsHighestBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields
+                          (testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodHighestPrice
-               && update.Flag == 1
+               && update.Flag == scaleFactor
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -297,31 +300,31 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsHighestAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.HighestAskPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedHighestAskPrice = 1.2345678m;
+        var expectedHighestAskPrice = 1.23456m;
+        var scaleFactor             = PQScaling.FindScaleFactor(expectedHighestAskPrice - 1);
         emptySummary.HighestAskPrice = expectedHighestAskPrice;
         Assert.IsTrue(emptySummary.IsHighestAskPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedHighestAskPrice, emptySummary.HighestAskPrice);
-        var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                              pricePrecisionSettings).ToList();
+        var sourceUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodHighestPrice, expectedHighestAskPrice,
-                                                    1 | PQFieldFlags.IsAskSideFlag);
+        var expectedFieldUpdate = new PQFieldUpdate
+            (PQFieldKeys.PeriodHighestPrice, expectedHighestAskPrice, (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag));
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsHighestAskPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsHighestAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
         sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
                                                                           pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodHighestPrice
-               && update.Flag == (1 | PQFieldFlags.IsAskSideFlag)
+               && update.Flag == (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag)
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -338,30 +341,31 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsLowestBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.LowestBidPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedLowestBidPrice = 1.2345678m;
+        var expectedLowestBidPrice = 1.23456m;
+        var scaleFactor            = PQScaling.FindScaleFactor(expectedLowestBidPrice - 1);
         emptySummary.LowestBidPrice = expectedLowestBidPrice;
         Assert.IsTrue(emptySummary.IsLowestBidPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedLowestBidPrice, emptySummary.LowestBidPrice);
-        var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                              pricePrecisionSettings).ToList();
+        var sourceUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodLowestPrice, expectedLowestBidPrice, 1);
+        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodLowestPrice, expectedLowestBidPrice, scaleFactor);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsLowestBidPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsLowestBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields
+                          (testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodLowestPrice
-               && update.Flag == 1
+               && update.Flag == scaleFactor
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -378,31 +382,32 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsLowestAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.LowestAskPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedLowestAskPrice = 1.2345678m;
+        var expectedLowestAskPrice = 1.23456m;
+        var scaleFactor            = PQScaling.FindScaleFactor(expectedLowestAskPrice - 1);
         emptySummary.LowestAskPrice = expectedLowestAskPrice;
         Assert.IsTrue(emptySummary.IsLowestAskPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedLowestAskPrice, emptySummary.LowestAskPrice);
-        var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                              pricePrecisionSettings).ToList();
+        var sourceUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodLowestPrice, expectedLowestAskPrice,
-                                                    1 | PQFieldFlags.IsAskSideFlag);
+                                                    (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag));
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsLowestAskPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsLowestAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields
+                          (testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodLowestPrice
-               && update.Flag == (1 | PQFieldFlags.IsAskSideFlag)
+               && update.Flag == (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag)
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -419,30 +424,31 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsEndBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.EndBidPrice);
-        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                             pricePrecisionSettings).Count());
+        Assert.AreEqual(0, emptySummary.GetDeltaUpdateFields
+                            (testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedEndBidPrice = 1.2345678m;
+        var expectedEndBidPrice = 1.23456m;
+        var scaleFactor         = PQScaling.FindScaleFactor(expectedEndBidPrice - 1);
         emptySummary.EndBidPrice = expectedEndBidPrice;
         Assert.IsTrue(emptySummary.IsEndBidPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedEndBidPrice, emptySummary.EndBidPrice);
-        var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                              pricePrecisionSettings).ToList();
+        var sourceUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
-        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodEndPrice, expectedEndBidPrice, 1);
+        var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodEndPrice, expectedEndBidPrice, scaleFactor);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsEndBidPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsEndBidPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields
+                          (testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodEndPrice
-               && update.Flag == 1
+               && update.Flag == scaleFactor
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -459,16 +465,15 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsTickCountUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.TickCount);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
         var expectedTickCount = uint.MaxValue;
         emptySummary.TickCount = expectedTickCount;
         Assert.IsTrue(emptySummary.IsTickCountUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedTickCount, emptySummary.TickCount);
-        var sourceUpdates = emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                              pricePrecisionSettings).ToList();
+        var sourceUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         var expectedFieldUpdate = new PQFieldUpdate(PQFieldKeys.PeriodTickCount, expectedTickCount);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -476,11 +481,11 @@ public class PQPricePeriodSummaryTests
         emptySummary.IsTickCountUpdated = false;
         Assert.IsFalse(emptySummary.IsTickCountUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update,
-                                                        pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue(emptySummary.GetDeltaUpdateFields
+                          (testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
-        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot,
-                                                                          pricePrecisionSettings)
+        sourceUpdates = (from update in emptySummary.GetDeltaUpdateFields
+                (testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodTickCount
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
@@ -498,10 +503,11 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsEndAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0m, emptySummary.EndAskPrice);
-        Assert.AreEqual(0, emptySummary
-                           .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
-        var expectedEndAskPrice = 1.2345678m;
+        var expectedEndAskPrice = 1.23456m;
+        var scaleFactor         = PQScaling.FindScaleFactor(expectedEndAskPrice - 1);
         emptySummary.EndAskPrice = expectedEndAskPrice;
         Assert.IsTrue(emptySummary.IsEndAskPriceUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
@@ -510,19 +516,20 @@ public class PQPricePeriodSummaryTests
             emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         var expectedFieldUpdate =
-            new PQFieldUpdate(PQFieldKeys.PeriodEndPrice, expectedEndAskPrice, 1 | PQFieldFlags.IsAskSideFlag);
+            new PQFieldUpdate
+                (PQFieldKeys.PeriodEndPrice, expectedEndAskPrice, (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag));
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
 
         emptySummary.IsEndAskPriceUpdated = false;
         Assert.IsFalse(emptySummary.IsEndAskPriceUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary
-                      .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue
+            (emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
         sourceUpdates = (from update in emptySummary
                 .GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
             where update.Id == PQFieldKeys.PeriodEndPrice
-               && update.Flag == (1 | PQFieldFlags.IsAskSideFlag)
+               && update.Flag == (byte)(scaleFactor | PQFieldFlags.IsAskSideFlag)
             select update).ToList();
         Assert.AreEqual(1, sourceUpdates.Count);
         Assert.AreEqual(expectedFieldUpdate, sourceUpdates[0]);
@@ -540,8 +547,8 @@ public class PQPricePeriodSummaryTests
         Assert.IsFalse(emptySummary.IsPeriodVolumeUpperBytesUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
         Assert.AreEqual(0L, emptySummary.PeriodVolume);
-        Assert.AreEqual(0, emptySummary
-                           .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
+        Assert.AreEqual
+            (0, emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).Count());
 
         var expectedPeriodVolume = long.MaxValue;
         emptySummary.PeriodVolume = expectedPeriodVolume;
@@ -549,8 +556,8 @@ public class PQPricePeriodSummaryTests
         Assert.IsTrue(emptySummary.IsPeriodVolumeUpperBytesUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
         Assert.AreEqual(expectedPeriodVolume, emptySummary.PeriodVolume);
-        var periodVolumeUpdates = emptySummary
-                                  .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
+        var periodVolumeUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(2, periodVolumeUpdates.Count);
         var lowerBytes         = (uint)emptySummary.PeriodVolume;
         var upperBytes         = (uint)(emptySummary.PeriodVolume >> 32);
@@ -562,16 +569,16 @@ public class PQPricePeriodSummaryTests
         emptySummary.IsPeriodVolumeLowerBytesUpdated = false;
         Assert.IsFalse(emptySummary.IsPeriodVolumeLowerBytesUpdated);
         Assert.IsTrue(emptySummary.HasUpdates);
-        periodVolumeUpdates = emptySummary
-                              .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
+        periodVolumeUpdates = emptySummary.GetDeltaUpdateFields
+            (testDateTime, StorageFlags.Update, pricePrecisionSettings).ToList();
         Assert.AreEqual(1, periodVolumeUpdates.Count);
         Assert.AreEqual(expectedUpperBytes, periodVolumeUpdates[0]);
 
         emptySummary.IsPeriodVolumeUpperBytesUpdated = false;
         Assert.IsFalse(emptySummary.IsPeriodVolumeUpperBytesUpdated);
         Assert.IsFalse(emptySummary.HasUpdates);
-        Assert.IsTrue(emptySummary
-                      .GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
+        Assert.IsTrue
+            (emptySummary.GetDeltaUpdateFields(testDateTime, StorageFlags.Update, pricePrecisionSettings).IsNullOrEmpty());
 
         periodVolumeUpdates = (from update in emptySummary
                 .GetDeltaUpdateFields(testDateTime, StorageFlags.Snapshot, pricePrecisionSettings)
@@ -610,7 +617,7 @@ public class PQPricePeriodSummaryTests
         var pqFieldUpdates =
             fullyPopulatedPeriodSummary.GetDeltaUpdateFields
                 (new DateTime(2017, 11, 04, 16, 33, 59), StorageFlags.Update, pricePrecisionSettings).ToList();
-        AssertPeriodSummaryContainsAllFields(pqFieldUpdates, fullyPopulatedPeriodSummary);
+        AssertPeriodSummaryContainsAllFields(pricePrecisionSettings, pqFieldUpdates, fullyPopulatedPeriodSummary);
     }
 
     [TestMethod]
@@ -620,7 +627,7 @@ public class PQPricePeriodSummaryTests
         var pqFieldUpdates =
             fullyPopulatedPeriodSummary.GetDeltaUpdateFields
                 (new DateTime(2017, 11, 04, 16, 33, 59), StorageFlags.Snapshot, pricePrecisionSettings).ToList();
-        AssertPeriodSummaryContainsAllFields(pqFieldUpdates, fullyPopulatedPeriodSummary);
+        AssertPeriodSummaryContainsAllFields(pricePrecisionSettings, pqFieldUpdates, fullyPopulatedPeriodSummary);
     }
 
     [TestMethod]
@@ -812,8 +819,11 @@ public class PQPricePeriodSummaryTests
         Assert.IsTrue(changingPeriodSummary.AreEquivalent(original, exactComparison));
     }
 
-    public static void AssertPeriodSummaryContainsAllFields(IList<PQFieldUpdate> checkFieldUpdates, IPQPricePeriodSummary periodSummary)
+    public static void AssertPeriodSummaryContainsAllFields
+        (IPQPriceVolumePublicationPrecisionSettings precisionSettings, IList<PQFieldUpdate> checkFieldUpdates, IPQPricePeriodSummary periodSummary)
     {
+        var priceScale  = precisionSettings.PriceScalingPrecision;
+        var volumeScale = precisionSettings.VolumeScalingPrecision;
         Assert.AreEqual(new PQFieldUpdate
                             (PQFieldKeys.PeriodStartDateTime, periodSummary.SummaryStartTime.GetHoursFromUnixEpoch()),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodStartDateTime));
@@ -826,30 +836,34 @@ public class PQPricePeriodSummaryTests
         fifthByte = periodSummary.SummaryEndTime.GetSubHourComponent().BreakLongToByteAndUint(out lowerFourBytes);
         Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodEndSubHourTime, lowerFourBytes, fifthByte),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodEndSubHourTime));
-        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodStartPrice, periodSummary.StartBidPrice, 1),
-                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodStartPrice, 1));
+        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodStartPrice, periodSummary.StartBidPrice, priceScale),
+                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodStartPrice, priceScale));
         Assert.AreEqual(new PQFieldUpdate
-                            (PQFieldKeys.PeriodStartPrice, periodSummary.StartAskPrice, PQFieldFlags.IsAskSideFlag | 1),
+                            (PQFieldKeys.PeriodStartPrice, PQScaling.Scale(periodSummary.StartAskPrice, priceScale)
+                           , (byte)(PQFieldFlags.IsAskSideFlag | priceScale)),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId
-                            (checkFieldUpdates, PQFieldKeys.PeriodStartPrice, PQFieldFlags.IsAskSideFlag | 1));
-        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodHighestPrice, periodSummary.HighestBidPrice, 1),
-                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodHighestPrice, 1));
+                            (checkFieldUpdates, PQFieldKeys.PeriodStartPrice, (byte)(PQFieldFlags.IsAskSideFlag | priceScale)));
+        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodHighestPrice, PQScaling.Scale(periodSummary.HighestBidPrice, priceScale), priceScale),
+                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodHighestPrice, priceScale));
         Assert.AreEqual(new PQFieldUpdate
-                            (PQFieldKeys.PeriodHighestPrice, periodSummary.HighestAskPrice, PQFieldFlags.IsAskSideFlag | 1),
+                            (PQFieldKeys.PeriodHighestPrice, PQScaling.Scale(periodSummary.HighestAskPrice, priceScale)
+                           , (byte)(PQFieldFlags.IsAskSideFlag | priceScale)),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId
-                            (checkFieldUpdates, PQFieldKeys.PeriodHighestPrice, PQFieldFlags.IsAskSideFlag | 1));
-        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodLowestPrice, periodSummary.LowestBidPrice, 1),
-                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodLowestPrice, 1));
+                            (checkFieldUpdates, PQFieldKeys.PeriodHighestPrice, (byte)(PQFieldFlags.IsAskSideFlag | priceScale)));
+        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodLowestPrice, PQScaling.Scale(periodSummary.LowestBidPrice, priceScale), priceScale),
+                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodLowestPrice, priceScale));
         Assert.AreEqual(new PQFieldUpdate
-                            (PQFieldKeys.PeriodLowestPrice, periodSummary.LowestAskPrice, PQFieldFlags.IsAskSideFlag | 1),
+                            (PQFieldKeys.PeriodLowestPrice, PQScaling.Scale(periodSummary.LowestAskPrice, priceScale)
+                           , (byte)(PQFieldFlags.IsAskSideFlag | priceScale)),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId
-                            (checkFieldUpdates, PQFieldKeys.PeriodLowestPrice, PQFieldFlags.IsAskSideFlag | 1));
-        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodEndPrice, periodSummary.EndBidPrice, 1),
-                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodEndPrice, 1));
+                            (checkFieldUpdates, PQFieldKeys.PeriodLowestPrice, (byte)(PQFieldFlags.IsAskSideFlag | priceScale)));
+        Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodEndPrice, PQScaling.Scale(periodSummary.EndBidPrice, priceScale), priceScale),
+                        PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodEndPrice, priceScale));
         Assert.AreEqual(new PQFieldUpdate
-                            (PQFieldKeys.PeriodEndPrice, periodSummary.EndAskPrice, PQFieldFlags.IsAskSideFlag | 1),
+                            (PQFieldKeys.PeriodEndPrice, PQScaling.Scale(periodSummary.EndAskPrice, priceScale)
+                           , (byte)(PQFieldFlags.IsAskSideFlag | priceScale)),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId
-                            (checkFieldUpdates, PQFieldKeys.PeriodEndPrice, PQFieldFlags.IsAskSideFlag | 1));
+                            (checkFieldUpdates, PQFieldKeys.PeriodEndPrice, (byte)(PQFieldFlags.IsAskSideFlag | priceScale)));
         Assert.AreEqual(new PQFieldUpdate(PQFieldKeys.PeriodTickCount, periodSummary.TickCount),
                         PQLevel0QuoteTests.ExtractFieldUpdateWithId(checkFieldUpdates, PQFieldKeys.PeriodTickCount));
         var lowerBytesPeriodVolume = (uint)periodSummary.PeriodVolume;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryTimeSeriesFileTests.cs
@@ -1,0 +1,166 @@
+﻿// Licensed under the MIT license.
+// Copyright Alexis Sawenko 2024 all rights reserved
+
+#region
+
+using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
+using FortitudeCommon.Monitoring.Logging;
+using FortitudeIO.TimeSeries;
+using FortitudeIO.TimeSeries.FileSystem.File;
+using FortitudeIO.TimeSeries.FileSystem.File.Buckets;
+using FortitudeIO.TimeSeries.FileSystem.Session;
+using FortitudeIO.TimeSeries.FileSystem.Session.Retrieval;
+using FortitudeMarketsApi.Configuration.ClientServerConfig.PricingConfig;
+using FortitudeMarketsApi.Pricing.LayeredBook;
+using FortitudeMarketsApi.Pricing.TimeSeries;
+using FortitudeMarketsCore.Pricing.Generators.Summaries;
+using FortitudeMarketsCore.Pricing.PQ.Generators.Summaries;
+using FortitudeMarketsCore.Pricing.PQ.Summaries;
+using FortitudeMarketsCore.Pricing.PQ.TimeSeries.FileSystem.File;
+using FortitudeMarketsCore.Pricing.Summaries;
+using static FortitudeIO.TimeSeries.MarketClassificationExtensions;
+using static FortitudeMarketsApi.Pricing.Quotes.QuoteLevel;
+using static FortitudeTests.FortitudeMarketsCore.Pricing.PQ.TimeSeries.FileSystem.File.TestWeeklyDataGeneratorFixture;
+
+#endregion
+
+namespace FortitudeTests.FortitudeMarketsCore.Pricing.PQ.TimeSeries.FileSystem.File;
+
+[TestClass]
+public class PriceSummaryTimeSeriesFileTests
+{
+    private static readonly IFLogger Logger = FLoggerFactory.Instance.GetLogger(typeof(PriceSummaryTimeSeriesFileTests));
+
+    private readonly Func<IPricePeriodSummary> asPQPricePeriodSummaryFactory        = () => new PQPricePeriodSummary();
+    private readonly Func<IPricePeriodSummary> asPQPriceStoragePeriodSummaryFactory = () => new PQPriceStoragePeriodSummary();
+    private readonly Func<IPricePeriodSummary> asPricePeriodSummaryFactory          = () => new PricePeriodSummary();
+
+    private PQPriceStoragePeriodSummaryGenerator pqPriceStorageSummaryGenerator = null!;
+    private PQPricePeriodSummaryGenerator        pqPriceSummaryGenerator        = null!;
+
+    private ITimeSeriesEntryFile<IPricePeriodSummary> priceSummaryFile      = null!;
+    private PricePeriodSummaryGenerator               priceSummaryGenerator = null!;
+
+    private IReaderSession<IPricePeriodSummary>? sessionReader;
+    private IWriterSession<IPricePeriodSummary>  sessionWriter = null!;
+
+    private SourceTickerQuoteInfo srcTkrQtInfo = null!;
+
+    private DateTime startOfWeek;
+
+
+    [TestInitialize]
+    public void Setup()
+    {
+        PagedMemoryMappedFile.LogMappingMessages = true;
+        srcTkrQtInfo =
+            new SourceTickerQuoteInfo
+                (19, "PriceSummaryTimeSeriesFileTests", 79, "PriceSummaryTests", Level0, Unknown
+               , 1, 0.1m, 10_000m, 100_000_000m, 10_000m, 1, LayerFlags.None);
+
+        var dateToGenerate   = DateTime.UtcNow.Date;
+        var currentDayOfWeek = dateToGenerate.DayOfWeek;
+        var dayDiff          = DayOfWeek.Sunday - currentDayOfWeek;
+        startOfWeek = dateToGenerate.AddDays(dayDiff);
+
+        var generateQuoteInfo = new GeneratePriceSummariesInfo(srcTkrQtInfo);
+        generateQuoteInfo.MidPriceGenerator!.StartTime  = startOfWeek;
+        generateQuoteInfo.MidPriceGenerator!.StartPrice = 200_042m;
+        generateQuoteInfo.MinimumVolume                 = 10_000;
+
+        priceSummaryGenerator          = new PricePeriodSummaryGenerator(generateQuoteInfo);
+        pqPriceSummaryGenerator        = new PQPricePeriodSummaryGenerator(generateQuoteInfo);
+        pqPriceStorageSummaryGenerator = new PQPriceStoragePeriodSummaryGenerator(generateQuoteInfo);
+    }
+
+    private PriceTimeSeriesFileParameters CreatePriceSummaryFileParameters
+    (FileFlags fileFlags = FileFlags.WriterOpened | FileFlags.HasInternalIndexInHeader, TimeSeriesPeriod filePeriod = TimeSeriesPeriod.OneWeek,
+        TimeSeriesPeriod entryPeriod = TimeSeriesPeriod.OneSecond, uint internalIndexSize = 7)
+    {
+        fileFlags |= FileFlags.WriterOpened | FileFlags.HasInternalIndexInHeader;
+
+        var testTimeSeriesFilePath = Path.Combine(Environment.CurrentDirectory, GenerateUniqueFileNameOffDateTime());
+        var timeSeriesFile         = new FileInfo(testTimeSeriesFilePath);
+        if (timeSeriesFile.Exists) timeSeriesFile.Delete();
+        var createTestCreateFileParameters =
+            new TimeSeriesFileParameters
+                (timeSeriesFile
+               , new Instrument("TestInstrumentName", "TestSourceName", InstrumentType.PriceSummaryPeriod, Unknown
+                              , entryPeriod, "TestInstrumentCategory"),
+                 filePeriod, DateTime.UtcNow.Date, internalIndexSize,
+                 fileFlags, 6);
+        return new PriceTimeSeriesFileParameters(srcTkrQtInfo, createTestCreateFileParameters);
+    }
+
+    [TestCleanup]
+    public void TearDown()
+    {
+        try
+        {
+            sessionReader?.Close();
+            sessionWriter.Close();
+            priceSummaryFile.Close();
+        }
+        catch (Exception ex)
+        {
+            Console.Out.WriteLine("Could not close all sessions. Got {0}", ex);
+        }
+        var dirInfo = new DirectoryInfo(Environment.CurrentDirectory);
+        DeleteTestFiles(dirInfo);
+    }
+
+    [TestMethod]
+    public void WeeklyDailyHourlyFile15sSummaryPeriods_TwoSmallPeriods_OriginalValuesAreReturned()
+    {
+        var createParams = CreatePriceSummaryFileParameters();
+        priceSummaryFile = new WeeklyDailyHourlyPriceSummaryTimeSeriesFile(createParams);
+        CreateNewTyped_TwoSmallPeriods_OriginalValuesAreReturned
+            (startOfWeek.AddDays(1), startOfWeek.AddDays(3), TimeSeriesPeriod.FifteenSeconds
+           , priceSummaryGenerator, asPricePeriodSummaryFactory);
+    }
+
+    public void CreateNewTyped_TwoSmallPeriods_OriginalValuesAreReturned<TEntry>
+    (DateTime firstPeriodSummaryTime, DateTime secondPeriodSummaryTime, TimeSeriesPeriod summaryPeriod
+      , IPricePeriodSummaryGenerator<TEntry> quoteGenerator, Func<IPricePeriodSummary> retrievalFactory)
+        where TEntry : class, IMutablePricePeriodSummary
+    {
+        var toPersistAndCheck = GenerateRepeatablePriceSummaries
+            (1, 10, 1, DayOfWeek.Wednesday, summaryPeriod, quoteGenerator, firstPeriodSummaryTime).ToList();
+        toPersistAndCheck.AddRange(GenerateRepeatablePriceSummaries
+                                       (1, 10, 1, DayOfWeek.Thursday, summaryPeriod, quoteGenerator, secondPeriodSummaryTime));
+
+
+        sessionWriter = priceSummaryFile.GetWriterSession()!;
+        foreach (var firstPeriod in toPersistAndCheck)
+        {
+            var result = sessionWriter.AppendEntry(firstPeriod);
+            Assert.AreEqual(StorageAttemptResult.PeriodRangeMatched, result.StorageAttemptResult);
+        }
+        priceSummaryFile.AutoCloseOnZeroSessions = false;
+        sessionWriter.Close();
+
+        Assert.AreEqual((uint)toPersistAndCheck.Count, priceSummaryFile.Header.TotalEntries);
+        sessionReader = priceSummaryFile.GetReaderSession();
+        var allEntriesReader = sessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
+        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
+        Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
+        Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
+        CompareExpectedToExtracted(toPersistAndCheck, storedItems);
+    }
+
+    private void CompareExpectedToExtracted(List<IPricePeriodSummary> originalList, List<IPricePeriodSummary> toCompareList)
+    {
+        for (var i = 0; i < originalList.Count; i++)
+        {
+            var originalEntry = originalList[i];
+            var compareEntry  = toCompareList[i];
+            if (!originalEntry.AreEquivalent(compareEntry))
+            {
+                Logger.Warn("Entries at {0} differ test failed \noriginal {1}\nretrieved {2} ", i, originalEntry, compareEntry);
+                FLoggerFactory.WaitUntilDrained();
+                Assert.Fail($"Entries at {i} differ test failed \noriginal {originalEntry}\nretrieved {compareEntry}.");
+            }
+        }
+    }
+}

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel0QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel0QuoteTimeSeriesFileTests.cs
@@ -54,7 +54,7 @@ public class WeeklyLevel0QuoteTimeSeriesFileTests
         level0SrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (19, "WeeklyLevel0QuoteTimeSeriesFileTests", 79, "PersistTest", Level0, Unknown
-               , 1, layerFlags: LayerFlags.None, lastTradedFlags: LastTradedFlags.None);
+               , 1, layerFlags: LayerFlags.None, lastTradedFlags: LastTradedFlags.None, roundingPrecision: 0.000001m);
 
         var dateToGenerate   = DateTime.UtcNow.Date;
         var currentDayOfWeek = dateToGenerate.DayOfWeek;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel1QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel1QuoteTimeSeriesFileTests.cs
@@ -54,7 +54,7 @@ public class WeeklyLevel1QuoteTimeSeriesFileTests
         level1SrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (19, "WeeklyLevel1QuoteTimeSeriesFileTests", 79, "PersistTest", Level1, Unknown
-               , 1, layerFlags: LayerFlags.None, lastTradedFlags: LastTradedFlags.None);
+               , 1, layerFlags: LayerFlags.None, lastTradedFlags: LastTradedFlags.None, roundingPrecision: 0.000001m);
 
 
         var dateToGenerate   = DateTime.UtcNow.Date;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel2QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel2QuoteTimeSeriesFileTests.cs
@@ -67,7 +67,7 @@ public class WeeklyLevel2QuoteTimeSeriesFileTests
         level2SrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (19, "WeeklyLevel2QuoteTimeSeriesFileTests", 79, "PersistTest", Level2, Unknown
-               , numberOfLayers, layerFlags: layerType.SupportedLayerFlags(), lastTradedFlags: LastTradedFlags.None);
+               , numberOfLayers, layerFlags: layerType.SupportedLayerFlags(), lastTradedFlags: LastTradedFlags.None, roundingPrecision: 0.000001m);
 
         var generateQuoteInfo = new GenerateQuoteInfo(level2SrcTkrQtInfo);
         generateQuoteInfo.MidPriceGenerator!.StartTime  = startOfWeek;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel3QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel3QuoteTimeSeriesFileTests.cs
@@ -67,7 +67,8 @@ public class WeeklyLevel3QuoteTimeSeriesFileTests
         level3SrcTkrQtInfo =
             new SourceTickerQuoteInfo
                 (19, "WeeklyLevel3QuoteTimeSeriesFileTests", 79, "PersistTest", Level3, Unknown
-               , numberOfLayers, layerFlags: layerType.SupportedLayerFlags(), lastTradedFlags: lastTradeType.SupportedLastTradedFlags());
+               , numberOfLayers, layerFlags: layerType.SupportedLayerFlags(), lastTradedFlags: lastTradeType.SupportedLastTradedFlags()
+               , roundingPrecision: 0.000001m);
 
         var generateQuoteInfo = new GenerateQuoteInfo(level3SrcTkrQtInfo);
         generateQuoteInfo.MidPriceGenerator!.StartTime  = startOfWeek;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/QuoteSequencedTestDataBuilder.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/Quotes/QuoteSequencedTestDataBuilder.cs
@@ -95,13 +95,13 @@ public class QuoteSequencedTestDataBuilder
         for (var i = 0; i < numLayers; i++)
         {
             var deltaPrice  = 0.00001m * i;
-            var deltaVolume = batchId * 10000 + 10000m * i;
+            var deltaVolume = batchId * 100_000 + 100_000m * i;
             var mutableBid  = level2Quote.BidBook[i]!;
             var mutableAsk  = level2Quote.AskBook[i]!;
             mutableBid.Price  = 0.791905m + batchId * 0.00001m - deltaPrice;
-            mutableBid.Volume = 30000 + deltaVolume;
+            mutableBid.Volume = 100_000 + deltaVolume;
             mutableAsk.Price  = 0.791906m + batchId * 0.00001m + deltaPrice;
-            mutableAsk.Volume = 30000 + deltaVolume;
+            mutableAsk.Volume = 100_0000 + deltaVolume;
 
             if (mutableBid is IMutableSourcePriceVolumeLayer mutableBidPriceVal)
                 SetupSourceNameOnLayer(mutableBidPriceVal, true, batchId);


### PR DESCRIPTION
 and updated failing tests.
Added test to persist and restore price summary to timeseries files.  More to follow.