### PR TITLE
Add parameters and allow TimeSeries Repository and files to read entries in reverse chronological order.  

### DIFF
--- a/src/FortitudeCommon/DataStructures/Lists/LinkedLists/DoublyLinkedList.cs
+++ b/src/FortitudeCommon/DataStructures/Lists/LinkedLists/DoublyLinkedList.cs
@@ -4,12 +4,13 @@
 #region
 
 using System.Collections;
+using FortitudeCommon.DataStructures.Memory;
 
 #endregion
 
 namespace FortitudeCommon.DataStructures.Lists.LinkedLists;
 
-public class DoublyLinkedList<T> : IDoublyLinkedList<T> where T : class, IDoublyLinkedListNode<T>
+public class DoublyLinkedList<T> : RecyclableObject, IDoublyLinkedList<T> where T : class, IDoublyLinkedListNode<T>
 {
     public T? Head { get; private set; }
     public T? Tail { get; private set; }
@@ -137,6 +138,19 @@ public class DoublyLinkedList<T> : IDoublyLinkedList<T> where T : class, IDoubly
 
         doublyLinkedList.Head = head;
         doublyLinkedList.Tail = tail;
+    }
+
+    public override void StateReset()
+    {
+        var currentNode = Head;
+        while (currentNode != null)
+        {
+            if (currentNode is IRecyclableObject recyclableNode) recyclableNode.DecrementRefCount();
+            currentNode = currentNode.Next;
+        }
+        Clear();
+
+        base.StateReset();
     }
 
     public void Clear()

--- a/src/FortitudeCommon/DataStructures/Lists/LinkedLists/DoublyLinkedListWrapperNode.cs
+++ b/src/FortitudeCommon/DataStructures/Lists/LinkedLists/DoublyLinkedListWrapperNode.cs
@@ -1,13 +1,34 @@
+// Licensed under the MIT license.
+// Copyright Alexis Sawenko 2024 all rights reserved
+
+#region
+
+using FortitudeCommon.DataStructures.Memory;
+
+#endregion
+
 namespace FortitudeCommon.DataStructures.Lists.LinkedLists;
 
-public class DoublyLinkedListWrapperNode<T> : IDoublyLinkedListNode<DoublyLinkedListWrapperNode<T>>
+public class DoublyLinkedListWrapperNode<T> : RecyclableObject, IDoublyLinkedListNode<DoublyLinkedListWrapperNode<T>>
 {
-    public DoublyLinkedListWrapperNode(T payload)
+    public DoublyLinkedListWrapperNode() => Payload = default!;
+
+    public DoublyLinkedListWrapperNode(T payload) => Payload = payload;
+
+    public T                               Payload  { get; set; }
+    public DoublyLinkedListWrapperNode<T>? Previous { get; set; }
+    public DoublyLinkedListWrapperNode<T>? Next     { get; set; }
+
+    public void Configure(T payload)
     {
         Payload = payload;
     }
 
-    public T Payload { get; set; }
-    public DoublyLinkedListWrapperNode<T>? Previous { get; set; }
-    public DoublyLinkedListWrapperNode<T>? Next { get; set; }
+    public override void StateReset()
+    {
+        if (Payload is RecyclableObject recyclablePayload) recyclablePayload.DecrementRefCount();
+        Payload  = default!;
+        Previous = Next = null;
+        base.StateReset();
+    }
 }

--- a/src/FortitudeCommon/DataStructures/Lists/LinkedLists/IDoublyLinkedList.cs
+++ b/src/FortitudeCommon/DataStructures/Lists/LinkedLists/IDoublyLinkedList.cs
@@ -1,9 +1,15 @@
 ﻿// Licensed under the MIT license.
 // Copyright Alexis Sawenko 2024 all rights reserved
 
+#region
+
+using FortitudeCommon.DataStructures.Memory;
+
+#endregion
+
 namespace FortitudeCommon.DataStructures.Lists.LinkedLists;
 
-public interface IDoublyLinkedList<T> : IEnumerable<T> where T : class, IDoublyLinkedListNode<T>
+public interface IDoublyLinkedList<T> : IEnumerable<T>, IRecyclableObject where T : class, IDoublyLinkedListNode<T>
 {
     T?   Head    { get; }
     T?   Tail    { get; }

--- a/src/FortitudeCommon/DataStructures/Memory/LimitedBlockingRecycler.cs
+++ b/src/FortitudeCommon/DataStructures/Memory/LimitedBlockingRecycler.cs
@@ -18,7 +18,7 @@ public interface ILimitedRecycler : IRecycler
 
 public class LimitedBlockingRecycler : ILimitedRecycler
 {
-    private readonly Recycler backingRecycler;
+    private readonly IRecycler backingRecycler;
 
     private readonly ConcurrentDictionary<Type, Semaphore> borrowCountMap = new();
 
@@ -31,6 +31,13 @@ public class LimitedBlockingRecycler : ILimitedRecycler
         MaxTypeBorrowLimit = maxTypeBorrowLimit;
 
         backingRecycler = new Recycler(shouldAutoRecycleOnRefCountZero, acceptNonCreatedObjects, throwWhenAttemptToRecycleRefCountNoZero);
+    }
+
+    public LimitedBlockingRecycler(int maxTypeBorrowLimit, IRecycler backingRecycler)
+    {
+        MaxTypeBorrowLimit = maxTypeBorrowLimit;
+
+        this.backingRecycler = backingRecycler;
     }
 
     public int MaxTypeBorrowLimit { get; set; }

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/Bucket.cs
@@ -38,6 +38,7 @@ public enum StorageAttemptResult
     EntryNotCompatible
   , NoBucketChecked
   , PeriodRangeMatched
+  , PriorBucketPeriod
   , NextBucketPeriod
   , StorageTimeNotSupported
   , NextFilePeriod

--- a/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/DataBucket.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/File/Buckets/DataBucket.cs
@@ -50,12 +50,14 @@ public abstract unsafe class DataBucket<TEntry, TBucket> : BucketBase<TEntry, TB
     private static readonly IFLogger Logger = FLoggerFactory.Instance.GetLogger(typeof(DataBucket<,>));
 
     protected ShiftableMemoryMappedFileView? BucketAppenderDataReaderFileView;
-    private   DataBucketHeader               cacheDataHeaderExtension;
-    private   LzmaEncoderParams              compressionParams = new();
-    private   long                           dataBucketHeaderExtensionRealignmentDelta;
-    private   LzmaDecoder?                   lzmaDecoder;
 
-    private LzmaEncoder?          lzmaEncoder;
+    private DataBucketHeader  cacheDataHeaderExtension;
+    private LzmaEncoderParams compressionParams = new();
+
+    private long         dataBucketHeaderExtensionRealignmentDelta;
+    private LzmaDecoder? lzmaDecoder;
+    private LzmaEncoder? lzmaEncoder;
+
     private DataBucketHeader*     mappedDataHeader;
     private FixedByteArrayBuffer? readerBuffer;
 
@@ -75,7 +77,8 @@ public abstract unsafe class DataBucket<TEntry, TBucket> : BucketBase<TEntry, TB
     internal virtual long EndOfBaseBucketHeaderSectionOffset => base.EndAllHeadersSectionFileOffset;
 
     internal long StartDataBucketHeaderSectionOffset => EndOfBaseBucketHeaderSectionOffset + dataBucketHeaderExtensionRealignmentDelta;
-    internal long StartOfDataSectionOffset           => EndAllHeadersSectionFileOffset;
+
+    internal long StartOfDataSectionOffset => EndAllHeadersSectionFileOffset;
 
     public IFixedByteArrayBuffer? DataWriterAtAppendLocation
     {
@@ -373,8 +376,9 @@ public abstract unsafe class IndexedDataBucket<TEntry, TBucket> : IndexedBucket<
 
     public override IEnumerable<TEntry> ReadEntries(IReaderContext<TEntry> readerContext)
     {
-        var matchingIndexOffsets = BucketIndexes.Values
-                                                .Where(bii => bii.Intersects(readerContext.PeriodRange));
+        var matchingIndexOffsets =
+            BucketIndexes.Values
+                         .Where(bii => bii.Intersects(readerContext.PeriodRange));
         if (matchingIndexOffsets.Any())
         {
             var first = matchingIndexOffsets.First();

--- a/src/FortitudeIO/TimeSeries/FileSystem/Session/ITimeSeriesSession.cs
+++ b/src/FortitudeIO/TimeSeries/FileSystem/Session/ITimeSeriesSession.cs
@@ -4,6 +4,7 @@
 #region
 
 using FortitudeCommon.Chronometry;
+using FortitudeCommon.DataStructures.Memory;
 using FortitudeIO.TimeSeries.FileSystem.File.Buckets;
 using FortitudeIO.TimeSeries.FileSystem.Session.Retrieval;
 
@@ -26,24 +27,56 @@ public interface IReaderSession<TEntry> : ITimeSeriesSession
 
     void VisitChildrenCacheAndClose();
 
-    IReaderContext<TEntry> GetAllEntriesReader
-    (EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject
+    IReaderContext<TEntry> AllChronologicalEntriesReader
+    (IRecycler resultRecycler, EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject
+      , ReaderOptions readerOptions = ReaderOptions.ConsumerControlled
       , Func<TEntry>? createNew = null);
 
-    IReaderContext<TEntry> GetEntriesBetweenReader
-    (UnboundedTimeRange? periodRange,
+    IReaderContext<TEntry> ChronologicalEntriesBetweenTimeRangeReader
+    (IRecycler resultRecycler, UnboundedTimeRange? periodRange,
+        EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject
+      , ReaderOptions readerOptions = ReaderOptions.ConsumerControlled
+      , Func<TEntry>? createNew = null);
+
+    IReaderContext<TEntry> AllChronologicalEntriesReader<TConcreteEntry>
+    (IRecycler resultRecycler, EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject
+      , ReaderOptions readerOptions = ReaderOptions.ConsumerControlled) where TConcreteEntry : class, TEntry, ITimeSeriesEntry<TConcreteEntry>, new();
+
+    IReaderContext<TEntry> ChronologicalEntriesBetweenTimeRangeReader<TConcreteEntry>
+    (IRecycler resultRecycler, UnboundedTimeRange? periodRange,
+        EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject
+      , ReaderOptions readerOptions = ReaderOptions.ConsumerControlled) where TConcreteEntry : class, TEntry, ITimeSeriesEntry<TConcreteEntry>, new();
+
+
+    public IReaderContext<TEntry> AllReverseChronologicalEntriesReader
+    (IRecycler resultsRecycler, EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject,
+        Func<TEntry>? createNew = null);
+
+    public IReaderContext<TEntry> ReverseChronologicalEntriesBetweenTimeRangeReader
+    (IRecycler resultsRecycler, UnboundedTimeRange? periodRange,
         EntryResultSourcing entryResultSourcing = EntryResultSourcing.ReuseSingletonObject,
         Func<TEntry>? createNew = null);
+
+    public IReaderContext<TEntry> AllReverseChronologicalEntriesReader<TConcreteEntry>
+        (IRecycler resultsRecycler, EntryResultSourcing entryResultSourcing = EntryResultSourcing.FromRecycler)
+        where TConcreteEntry : class, TEntry, ITimeSeriesEntry<TConcreteEntry>, new();
+
+    public IReaderContext<TEntry> ReverseChronologicalEntriesBetweenTimeRangeReader<TConcreteEntry>
+    (IRecycler resultsRecycler, UnboundedTimeRange? periodRange,
+        EntryResultSourcing entryResultSourcing = EntryResultSourcing.FromRecycler)
+        where TConcreteEntry : class, TEntry, ITimeSeriesEntry<TConcreteEntry>, new();
 }
 
 public struct AppendResult
 {
     public AppendResult(StorageAttemptResult storageAttemptResult) => StorageAttemptResult = storageAttemptResult;
-    public int?                 SerializedSize       { get; set; }
-    public uint?                BucketId             { get; set; }
-    public long?                FileOffset           { get; set; }
-    public DateTime             StorageTime          { get; set; }
+
     public StorageAttemptResult StorageAttemptResult { get; set; }
+
+    public int?     SerializedSize { get; set; }
+    public uint?    BucketId       { get; set; }
+    public long?    FileOffset     { get; set; }
+    public DateTime StorageTime    { get; set; }
 }
 
 public interface IWriterSession<in TEntry> : ITimeSeriesSession where TEntry : ITimeSeriesEntry<TEntry>

--- a/src/FortitudeMarketsApi/Indicators/Pricing/SameIndicatorBidAskInstantChain.cs
+++ b/src/FortitudeMarketsApi/Indicators/Pricing/SameIndicatorBidAskInstantChain.cs
@@ -24,15 +24,6 @@ public interface ISameIndicatorBidAskInstantChain : IDoublyLinkedList<IBidAskIns
 
 public class SameIndicatorBidAskInstantChain : DoublyLinkedList<IBidAskInstant>, ISameIndicatorBidAskInstantChain
 {
-    private const int NumRecentRecycleTimes = 5;
-
-    private int isInRecycler;
-
-    protected DateTime[] LastRecycleTimes = new DateTime[NumRecentRecycleTimes];
-
-    protected int RecycleCount;
-    private   int refCount = 1;
-
     public long IndicatorSourceTickerId { get; set; }
 
     public TimePeriod CoveringPeriod { get; set; }
@@ -55,65 +46,6 @@ public class SameIndicatorBidAskInstantChain : DoublyLinkedList<IBidAskInstant>,
         node.DecrementRefCount();
         return node;
     }
-
-    public IRecycler? Recycler { get; set; }
-
-    public int RefCount => refCount;
-
-    public bool AutoRecycleAtRefCountZero { get; set; }
-    public bool IsInRecycler
-    {
-        get => isInRecycler != 0;
-        set => isInRecycler = value ? 1 : 0;
-    }
-
-    public virtual int DecrementRefCount()
-    {
-        var shouldRecycle = !IsInRecycler && Interlocked.Decrement(ref refCount) <= 0 && AutoRecycleAtRefCountZero;
-        var currentNode   = Head;
-        while (currentNode != null)
-        {
-            if (shouldRecycle) Remove(currentNode);
-            currentNode.DecrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        if (shouldRecycle) Recycle();
-        return refCount;
-    }
-
-    public virtual int IncrementRefCount()
-    {
-        var currentNode = Head;
-        while (currentNode != null)
-        {
-            currentNode.IncrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        return Interlocked.Increment(ref refCount);
-    }
-
-    public virtual bool Recycle()
-    {
-        if (IsInRecycler) return true;
-        if (Recycler == null) return false;
-        if (Interlocked.CompareExchange(ref isInRecycler, 1, 0) != 0) return false;
-
-        LastRecycleTimes[RecycleCount % NumRecentRecycleTimes] = DateTime.UtcNow;
-        Interlocked.Increment(ref RecycleCount);
-        Recycler.Recycle(this);
-
-        return true;
-    }
-
-    public virtual void StateReset()
-    {
-        IndicatorSourceTickerId = 0;
-
-        CoveringPeriod = new TimePeriod(TimeSeriesPeriod.None);
-
-        refCount = 0;
-    }
-
 
     public void Configure(long indicatorSourceTickerId, TimePeriod coveringPeriod)
     {

--- a/src/FortitudeMarketsApi/Indicators/Pricing/SameIndicatorValidRangeBidAskPeriodChain.cs
+++ b/src/FortitudeMarketsApi/Indicators/Pricing/SameIndicatorValidRangeBidAskPeriodChain.cs
@@ -24,15 +24,6 @@ public interface ISameIndicatorValidRangeBidAskPeriodChain : IDoublyLinkedList<I
 
 public class SameIndicatorValidRangeBidAskPeriodChain : DoublyLinkedList<IValidRangeBidAskPeriod>, ISameIndicatorValidRangeBidAskPeriodChain
 {
-    private const int NumRecentRecycleTimes = 5;
-
-    private int isInRecycler;
-
-    protected DateTime[] LastRecycleTimes = new DateTime[NumRecentRecycleTimes];
-
-    protected int RecycleCount;
-    private   int refCount = 1;
-
     public long IndicatorSourceTickerId { get; set; }
 
     public TimePeriod CoveringPeriod { get; set; }
@@ -55,65 +46,6 @@ public class SameIndicatorValidRangeBidAskPeriodChain : DoublyLinkedList<IValidR
         node.DecrementRefCount();
         return node;
     }
-
-    public IRecycler? Recycler { get; set; }
-
-    public int RefCount => refCount;
-
-    public bool AutoRecycleAtRefCountZero { get; set; }
-    public bool IsInRecycler
-    {
-        get => isInRecycler != 0;
-        set => isInRecycler = value ? 1 : 0;
-    }
-
-    public virtual int DecrementRefCount()
-    {
-        var shouldRecycle = !IsInRecycler && Interlocked.Decrement(ref refCount) <= 0 && AutoRecycleAtRefCountZero;
-        var currentNode   = Head;
-        while (currentNode != null)
-        {
-            if (shouldRecycle) Remove(currentNode);
-            currentNode.DecrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        if (shouldRecycle) Recycle();
-        return refCount;
-    }
-
-    public virtual int IncrementRefCount()
-    {
-        var currentNode = Head;
-        while (currentNode != null)
-        {
-            currentNode.IncrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        return Interlocked.Increment(ref refCount);
-    }
-
-    public virtual bool Recycle()
-    {
-        if (IsInRecycler) return true;
-        if (Recycler == null) return false;
-        if (Interlocked.CompareExchange(ref isInRecycler, 1, 0) != 0) return false;
-
-        LastRecycleTimes[RecycleCount % NumRecentRecycleTimes] = DateTime.UtcNow;
-        Interlocked.Increment(ref RecycleCount);
-        Recycler.Recycle(this);
-
-        return true;
-    }
-
-    public virtual void StateReset()
-    {
-        IndicatorSourceTickerId = 0;
-
-        CoveringPeriod = new TimePeriod(TimeSeriesPeriod.None);
-
-        refCount = 0;
-    }
-
 
     public void Configure(long indicatorSourceTickerId, TimePeriod coveringPeriod)
     {

--- a/src/FortitudeMarketsApi/Indicators/Pricing/VaryingIndicatorBidAskInstantChain.cs
+++ b/src/FortitudeMarketsApi/Indicators/Pricing/VaryingIndicatorBidAskInstantChain.cs
@@ -19,26 +19,6 @@ public interface IVaryingIndicatorBidAskInstantChain : IDoublyLinkedList<IIndica
 
 public class VaryingIndicatorBidAskInstantChain : DoublyLinkedList<IIndicatorValidRangeBidAskPeriod>, IVaryingIndicatorBidAskInstantChain
 {
-    private const int NumRecentRecycleTimes = 5;
-
-    private int isInRecycler;
-
-    protected DateTime[] LastRecycleTimes = new DateTime[NumRecentRecycleTimes];
-
-    protected int RecycleCount;
-    private   int refCount = 1;
-
-    public IRecycler? Recycler { get; set; }
-
-    public int RefCount => refCount;
-
-    public bool AutoRecycleAtRefCountZero { get; set; }
-    public bool IsInRecycler
-    {
-        get => isInRecycler != 0;
-        set => isInRecycler = value ? 1 : 0;
-    }
-
     public IIndicatorValidRangeBidAskPeriod RefIncAddFirst(IIndicatorValidRangeBidAskPeriod node)
     {
         node.IncrementRefCount();
@@ -56,48 +36,5 @@ public class VaryingIndicatorBidAskInstantChain : DoublyLinkedList<IIndicatorVal
         Remove(node);
         node.DecrementRefCount();
         return node;
-    }
-
-    public virtual int DecrementRefCount()
-    {
-        var shouldRecycle = !IsInRecycler && Interlocked.Decrement(ref refCount) <= 0 && AutoRecycleAtRefCountZero;
-        var currentNode   = Head;
-        while (currentNode != null)
-        {
-            if (shouldRecycle) Remove(currentNode);
-            currentNode.DecrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        if (shouldRecycle) Recycle();
-        return refCount;
-    }
-
-    public virtual int IncrementRefCount()
-    {
-        var currentNode = Head;
-        while (currentNode != null)
-        {
-            currentNode.IncrementRefCount();
-            currentNode = currentNode.Next;
-        }
-        return Interlocked.Increment(ref refCount);
-    }
-
-    public virtual bool Recycle()
-    {
-        if (IsInRecycler) return true;
-        if (Recycler == null) return false;
-        if (Interlocked.CompareExchange(ref isInRecycler, 1, 0) != 0) return false;
-
-        LastRecycleTimes[RecycleCount % NumRecentRecycleTimes] = DateTime.UtcNow;
-        Interlocked.Increment(ref RecycleCount);
-        Recycler.Recycle(this);
-
-        return true;
-    }
-
-    public virtual void StateReset()
-    {
-        refCount = 0;
     }
 }

--- a/src/FortitudeMarketsCore/Indicators/IndicatorServiceRegistryRule.cs
+++ b/src/FortitudeMarketsCore/Indicators/IndicatorServiceRegistryRule.cs
@@ -15,7 +15,7 @@ using FortitudeMarketsApi.Pricing;
 using FortitudeMarketsApi.Pricing.Quotes;
 using FortitudeMarketsCore.Indicators.Config;
 using FortitudeMarketsCore.Indicators.Persistence;
-using FortitudeMarketsCore.Indicators.Pricing.MovingAverage;
+using FortitudeMarketsCore.Indicators.Pricing.MovingAverage.TimeWeighted;
 using FortitudeMarketsCore.Indicators.Pricing.Parameters;
 using FortitudeMarketsCore.Indicators.Pricing.PeriodSummaries;
 using FortitudeMarketsCore.Indicators.Pricing.PeriodSummaries.Construction;

--- a/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/MovingAverageConstants.cs
+++ b/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/MovingAverageConstants.cs
@@ -11,12 +11,12 @@ namespace FortitudeMarketsCore.Indicators.Pricing.MovingAverage;
 
 public static class MovingAverageConstants
 {
-    public const string MovingAverageBase         = $"{IndicatorServiceConstants.IndicatorsBase}.MovingAverage";
-    public const string MovingAverageLiveTemplate = $"{MovingAverageBase}.Live.{{0}}.{{1}}.{{2}}";
-    public const string MovingAverageShortPeriod  = $"{MovingAverageBase}.Live.{{0}}.{{1}}.ShortPeriod";
+    public const string MovingAverageBase                    = $"{IndicatorServiceConstants.IndicatorsBase}.MovingAverage";
+    public const string MovingAverageLiveTemplate            = $"{MovingAverageBase}.Live.{{0}}.{{1}}.{{2}}";
+    public const string TimeWeightedMovingAverageShortPeriod = $"{MovingAverageBase}.Live.{{0}}.{{1}}.TimeWeighted.ShortPeriod";
 
 
-    public static string MovingAverageLiveShortPeriodRequest
+    public static string TimeWeightedMovingAverageLiveShortPeriodRequest
         (this SourceTickerIdentifier sourceTicker) =>
-        string.Format(MovingAverageShortPeriod, sourceTicker.Source, sourceTicker.Ticker);
+        string.Format(TimeWeightedMovingAverageShortPeriod, sourceTicker.Source, sourceTicker.Ticker);
 }

--- a/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/MovingAverageOffset.cs
+++ b/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/MovingAverageOffset.cs
@@ -37,9 +37,10 @@ public struct MovingAverageOffset
         LatestOffsetNumberOfPeriods = latestOffsetNumberOfPeriods;
     }
 
-    public TimePeriod AveragePeriod               { get; }
-    public TimePeriod LatestOffsetPeriod          { get; }
-    public int        LatestOffsetNumberOfPeriods { get; }
+    public TimePeriod AveragePeriod      { get; }
+    public TimePeriod LatestOffsetPeriod { get; }
+
+    public int LatestOffsetNumberOfPeriods { get; }
 }
 
 public static class MovingAverageParamsExtensions

--- a/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/TimeWeighted/MovingAveragePublishRequestState.cs
+++ b/src/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/TimeWeighted/MovingAveragePublishRequestState.cs
@@ -12,7 +12,7 @@ using FortitudeMarketsCore.Indicators.Pricing.Parameters;
 
 #endregion
 
-namespace FortitudeMarketsCore.Indicators.Pricing.MovingAverage;
+namespace FortitudeMarketsCore.Indicators.Pricing.MovingAverage.TimeWeighted;
 
 public class MovingAveragePublishRequestState
 {

--- a/src/FortitudeMarketsCore/Indicators/Pricing/PeriodSummaries/Construction/SummaryStreamRequestAttendant.cs
+++ b/src/FortitudeMarketsCore/Indicators/Pricing/PeriodSummaries/Construction/SummaryStreamRequestAttendant.cs
@@ -273,9 +273,10 @@ public class QuoteToSummaryStreamRequestAttendant<TQuote> : StreamRequestAttenda
             (StreamRequest.RequestTimeRange?.FromTime ?? State.QuotesRepoRange.FromTime
            , endHistoricalPeriods.Min(StreamRequest.RequestTimeRange?.ToTime));
 
-        var historicalQuotesChannel = ConstructingRule.CreateChannelFactory<TQuote>(ReceiveHistoricalQuote, new LimitedBlockingRecycler(200));
-        var channelRequest          = historicalQuotesChannel.ToChannelPublishRequest(-1, 50);
-        var request                 = channelRequest.ToHistoricalQuotesRequest(State.PricingInstrumentId, requestHistoricalRange);
+        var historicalQuotesChannel = ConstructingRule.CreateChannelFactory<TQuote>
+            (ReceiveHistoricalQuote, new LimitedBlockingRecycler(200, ConstructingRule.Context.PooledRecycler));
+        var channelRequest = historicalQuotesChannel.ToChannelPublishRequest(-1, 50);
+        var request        = channelRequest.ToHistoricalQuotesRequest(State.PricingInstrumentId, requestHistoricalRange);
 
         var retrieving = await ConstructingRule.RequestAsync<HistoricalQuotesRequest<TQuote>, bool>(request.RequestAddress, request);
         if (!retrieving) await historicalQuotesChannel.PublishComplete(ConstructingRule);

--- a/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/BusRules/HistoricalPricePeriodSummaryRetrievalRule.cs
+++ b/src/FortitudeMarketsCore/Pricing/PQ/TimeSeries/BusRules/HistoricalPricePeriodSummaryRetrievalRule.cs
@@ -146,8 +146,9 @@ public class HistoricalPricePeriodSummaryRetrievalRule : TimeSeriesRepositoryAcc
         if (instrument == null) return Enumerable.Empty<PricePeriodSummary>();
         var readerSession = TimeSeriesRepository!.GetReaderSession<PricePeriodSummary>(instrument, responseRequest.TimeRange);
         if (readerSession == null) return Enumerable.Empty<PricePeriodSummary>();
-        var readerContext = readerSession.GetEntriesBetweenReader(responseRequest.TimeRange, EntryResultSourcing.FromFactoryFuncUnlimited
-                                                                , () => new PricePeriodSummary());
+        var readerContext = readerSession.ChronologicalEntriesBetweenTimeRangeReader
+            (Context.PooledRecycler, responseRequest.TimeRange, EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible
+           , () => new PricePeriodSummary());
 
         return readerContext.ResultEnumerable;
     }
@@ -158,8 +159,8 @@ public class HistoricalPricePeriodSummaryRetrievalRule : TimeSeriesRepositoryAcc
         if (instrument == null) return false;
         var readerSession = TimeSeriesRepository!.GetReaderSession<PricePeriodSummary>(instrument, streamRequest.TimeRange);
         if (readerSession == null) return false;
-        var readerContext = readerSession.GetEntriesBetweenReader
-            (streamRequest.TimeRange, EntryResultSourcing.FromFactoryFuncUnlimited
+        var readerContext = readerSession.ChronologicalEntriesBetweenTimeRangeReader
+            (Context.PooledRecycler, streamRequest.TimeRange, EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible
            , streamRequest.ChannelRequest.PublishChannel.GetChannelEventOrNew<PricePeriodSummary>());
 
         if (streamRequest.ChannelRequest.BatchSize > 1) readerContext.BatchLimit   = streamRequest.ChannelRequest.BatchSize;

--- a/src/FortitudeMarketsCore/Pricing/Quotes/TickInstant.cs
+++ b/src/FortitudeMarketsCore/Pricing/Quotes/TickInstant.cs
@@ -3,6 +3,7 @@
 
 #region
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using FortitudeCommon.Chronometry;
 using FortitudeCommon.DataStructures.Lists.LinkedLists;
@@ -124,6 +125,7 @@ public class TickInstant : ReusableObject<ITickInstant>, IMutableTickInstant, IT
         var clientReceivedTimeSame = ClientReceivedTime.Equals(other.ClientReceivedTime);
 
         var allEquivalent = srcTickersAreEquivalent && sourceTimesSame && replayIsSame && staleIsSame && singlePriceSame && clientReceivedTimeSame;
+        if (!allEquivalent) Debugger.Break();
         return allEquivalent;
     }
 

--- a/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeIO/TimeSeries/FileSystem/File/TimeSeriesFileTests.cs
@@ -4,6 +4,7 @@
 #region
 
 using FortitudeCommon.Chronometry;
+using FortitudeCommon.DataStructures.Memory;
 using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeCommon.Extensions;
 using FortitudeCommon.Monitoring.Logging;
@@ -119,8 +120,9 @@ public class TimeSeriesFileTests
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, oneWeekFile.Header.TotalEntries);
         readerSession = oneWeekFile.GetReaderSession();
-        var allEntriesReader = readerSession.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, createNewEntryFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = readerSession.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, createNewEntryFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -148,8 +150,9 @@ public class TimeSeriesFileTests
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, oneWeekFile.Header.TotalEntries);
         readerSession = oneWeekFile.GetReaderSession();
-        var allEntriesReader = readerSession.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, createNewEntryFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = readerSession.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, createNewEntryFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -200,15 +203,17 @@ public class TimeSeriesFileTests
         }
 
         readerSession = oneWeekFile.GetReaderSession();
-        var allEntriesReader = readerSession.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, createNewEntryFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = readerSession.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, createNewEntryFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
         CompareExpectedToExtracted(toPersistAndCheck, storedItems);
         var newReaderSession = oneWeekFile.GetReaderSession();
         Assert.AreNotSame(readerSession, newReaderSession);
-        var newEntriesReader = readerSession.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, createNewEntryFactory);
+        var newEntriesReader = readerSession.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, createNewEntryFactory);
         newEntriesReader.ResultPublishFlags = ResultFlags.CopyToList;
         newEntriesReader.RunReader();
         var listResults = newEntriesReader.ResultList;

--- a/src/FortitudeTests/FortitudeMarketsCore/Indicators/Persistence/CyclingInstrumentChainingEntryPersisterRuleTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Indicators/Persistence/CyclingInstrumentChainingEntryPersisterRuleTests.cs
@@ -183,7 +183,8 @@ public class CyclingInstrumentChainingEntryPersisterRuleTests : OneOfEachMessage
             Assert.IsTrue(fileInfo.HasInstrument);
             using var reader = timeSeriesRepository.GetReaderSession<PricePeriodSummary>(instrument);
 
-            var entryReader = reader!.GetAllEntriesReader(EntryResultSourcing.NewEachEntryUnlimited, () => new PricePeriodSummary());
+            var entryReader = reader!.AllChronologicalEntriesReader
+                (new Recycler(), EntryResultSourcing.NewEachEntryUnlimited, ReaderOptions.ReadFastAsPossible, () => new PricePeriodSummary());
             var readEntries = entryReader.ResultEnumerable.ToList();
 
             Console.Out.WriteLine($"Read for  {pricingInstrumentId} it has {readEntries.Count} instruments");

--- a/src/FortitudeTests/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/TimeWeighted/LiveShortPeriodMovingAveragePublisherRuleTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Indicators/Pricing/MovingAverage/TimeWeighted/LiveShortPeriodMovingAveragePublisherRuleTests.cs
@@ -23,7 +23,7 @@ using static FortitudeMarketsApi.Pricing.Quotes.TickerDetailLevel;
 
 #endregion
 
-namespace FortitudeTests.FortitudeMarketsCore.Indicators.Pricing.MovingAverage;
+namespace FortitudeTests.FortitudeMarketsCore.Indicators.Pricing.MovingAverage.TimeWeighted;
 
 [TestClass]
 public class LiveShortPeriodMovingAveragePublisherRuleTests : OneOfEachMessageQueueTypeTestSetup

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/PriceSummaryTimeSeriesFileTests.cs
@@ -4,6 +4,7 @@
 #region
 
 using FortitudeCommon.Chronometry;
+using FortitudeCommon.DataStructures.Memory;
 using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeCommon.Extensions;
 using FortitudeCommon.Monitoring.Logging;
@@ -297,9 +298,10 @@ public class PriceSummaryTimeSeriesFileTests
         sessionWriter.Close();
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, tsf.Header.TotalEntries);
-        using var sessionReader    = tsf.GetReaderSession();
-        var       allEntriesReader = sessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var       storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        using var sessionReader = tsf.GetReaderSession();
+        var allEntriesReader = sessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel1QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel1QuoteTimeSeriesFileTests.cs
@@ -3,6 +3,7 @@
 
 #region
 
+using FortitudeCommon.DataStructures.Memory;
 using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeCommon.Extensions;
 using FortitudeCommon.Monitoring.Logging;
@@ -149,8 +150,9 @@ public class WeeklyLevel1QuoteTimeSeriesFileTests
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, level1OneWeekFile.Header.TotalEntries);
         level1SessionReader = level1OneWeekFile.GetReaderSession();
-        var allEntriesReader = level1SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = level1SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -203,15 +205,17 @@ public class WeeklyLevel1QuoteTimeSeriesFileTests
         Assert.AreEqual((uint)toPersistAndCheck.Count, level1OneWeekFile.Header.TotalEntries);
 
         level1SessionReader = level1OneWeekFile.GetReaderSession();
-        var allEntriesReader = level1SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = level1SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
         CompareExpectedToExtracted(toPersistAndCheck, storedItems);
         var newReaderSession = level1OneWeekFile.GetReaderSession();
         Assert.AreNotSame(level1SessionReader, newReaderSession);
-        var newEntriesReader = level1SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
+        var newEntriesReader = level1SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
         newEntriesReader.ResultPublishFlags = ResultFlags.CopyToList;
         newEntriesReader.RunReader();
         var listResults = newEntriesReader.ResultList;

--- a/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel2QuoteTimeSeriesFileTests.cs
+++ b/src/FortitudeTests/FortitudeMarketsCore/Pricing/PQ/TimeSeries/FileSystem/File/WeeklyLevel2QuoteTimeSeriesFileTests.cs
@@ -3,6 +3,7 @@
 
 #region
 
+using FortitudeCommon.DataStructures.Memory;
 using FortitudeCommon.DataStructures.Memory.UnmanagedMemory.MemoryMappedFiles;
 using FortitudeCommon.Extensions;
 using FortitudeCommon.Monitoring.Logging;
@@ -306,8 +307,9 @@ public class WeeklyLevel2QuoteTimeSeriesFileTests
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, level2OneWeekFile.Header.TotalEntries);
         level2SessionReader = level2OneWeekFile.GetReaderSession();
-        var allEntriesReader = level2SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = level2SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -349,8 +351,9 @@ public class WeeklyLevel2QuoteTimeSeriesFileTests
 
         Assert.AreEqual((uint)toPersistAndCheck.Count, level2OneWeekFile.Header.TotalEntries);
         level2SessionReader = level2OneWeekFile.GetReaderSession();
-        var allEntriesReader = level2SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = level2SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
@@ -403,15 +406,17 @@ public class WeeklyLevel2QuoteTimeSeriesFileTests
         Assert.AreEqual((uint)toPersistAndCheck.Count, level2OneWeekFile.Header.TotalEntries);
 
         level2SessionReader = level2OneWeekFile.GetReaderSession();
-        var allEntriesReader = level2SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
-        var storedItems      = allEntriesReader.ResultEnumerable.ToList();
+        var allEntriesReader = level2SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
+        var storedItems = allEntriesReader.ResultEnumerable.ToList();
         Assert.AreEqual(toPersistAndCheck.Count, allEntriesReader.CountMatch);
         Assert.AreEqual(allEntriesReader.CountMatch, allEntriesReader.CountProcessed);
         Assert.AreEqual(toPersistAndCheck.Count, storedItems.Count);
         CompareExpectedToExtracted(toPersistAndCheck, storedItems);
         var newReaderSession = level2OneWeekFile.GetReaderSession();
         Assert.AreNotSame(level2SessionReader, newReaderSession);
-        var newEntriesReader = level2SessionReader.GetAllEntriesReader(EntryResultSourcing.FromFactoryFuncUnlimited, retrievalFactory);
+        var newEntriesReader = level2SessionReader.AllChronologicalEntriesReader
+            (new Recycler(), EntryResultSourcing.FromFactoryFuncUnlimited, ReaderOptions.ReadFastAsPossible, retrievalFactory);
         newEntriesReader.ResultPublishFlags = ResultFlags.CopyToList;
         newEntriesReader.RunReader();
         var listResults = newEntriesReader.ResultList;


### PR DESCRIPTION
This will allow Rules to request an unlimited period from current time and allow them to stop when their criteria has been met.